### PR TITLE
Add missing type checks in native code, and an exhaustive test suite

### DIFF
--- a/src/main/c/narcissus.c
+++ b/src/main/c/narcissus.c
@@ -28,255 +28,318 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+// The JNI version required by this library. JNI 1.6 is required for ExceptionCheck(), EnsureLocalCapacity()
+// and DeleteLocalRef(), and is supported by every JVM that this library supports (Java 7 and above).
+#define NARCISSUS_JNI_VERSION JNI_VERSION_1_6
+
+// Modifier bits, from the JVM specification (java.lang.reflect.Modifier)
+#define MODIFIER_STATIC    0x0008
+#define MODIFIER_INTERFACE 0x0200
+#define MODIFIER_ABSTRACT  0x0400
+
+// The maximum number of parameters a method may declare. The JVM specification limits a method to 255
+// argument slots, so no loadable method can have more parameters than this. Method invocation buffers are
+// sized by this constant, so that no buffer is ever sized from a caller-supplied argument count.
+#define MAX_METHOD_PARAMS 255
+
+// The largest exception message assembled by this library
+#define MAX_MSG_LEN 128
+
+// The number of local references that a method invocation needs over and above one per parameter (for the
+// boxed varargs array, the receiver's class, and the like)
+#define LOCAL_REF_SLACK 16
+
 // -----------------------------------------------------------------------------------------------------------------
 
-bool thrown(JNIEnv* env) {
-    return (*env)->ExceptionOccurred(env);
+// Returns true if an exception is pending in the current thread. Uses ExceptionCheck() rather than
+// ExceptionOccurred(), because ExceptionOccurred() returns a new local reference on every call, and this
+// function is called several times per JNI entry point.
+static bool thrown(JNIEnv* env) {
+    return (*env)->ExceptionCheck(env);
 }
 
 // -----------------------------------------------------------------------------------------------------------------
 
 // Prelookup of frequently-used classes and methods:
 
-jclass Class_class;
-jmethodID Class_isArray_methodID;
-jmethodID Class_getComponentType_methodID;
-jmethodID Class_getName_methodID;
-jmethodID Class_isPrimitive_methodID;
-jmethodID Class_getModifiers_methodID;
+static jclass Class_class;
+static jmethodID Class_isArray_methodID;
+static jmethodID Class_getComponentType_methodID;
+static jmethodID Class_isPrimitive_methodID;
+static jmethodID Class_getModifiers_methodID;
 
-jclass void_class;
+static jclass void_class;
 
-jclass Integer_class;
-jclass int_class;
-jmethodID Integer_intValue_methodID;
+static jclass Integer_class;
+static jclass int_class;
+static jmethodID Integer_intValue_methodID;
 
-jclass Long_class;
-jclass long_class;
-jmethodID Long_longValue_methodID;
+static jclass Long_class;
+static jclass long_class;
+static jmethodID Long_longValue_methodID;
 
-jclass Short_class;
-jclass short_class;
-jmethodID Short_shortValue_methodID;
+static jclass Short_class;
+static jclass short_class;
+static jmethodID Short_shortValue_methodID;
 
-jclass Character_class;
-jclass char_class;
-jmethodID Character_charValue_methodID;
+static jclass Character_class;
+static jclass char_class;
+static jmethodID Character_charValue_methodID;
 
-jclass Boolean_class;
-jclass boolean_class;
-jmethodID Boolean_booleanValue_methodID;
+static jclass Boolean_class;
+static jclass boolean_class;
+static jmethodID Boolean_booleanValue_methodID;
 
-jclass Byte_class;
-jclass byte_class;
-jmethodID Byte_byteValue_methodID;
+static jclass Byte_class;
+static jclass byte_class;
+static jmethodID Byte_byteValue_methodID;
 
-jclass Float_class;
-jclass float_class;
-jmethodID Float_floatValue_methodID;
+static jclass Float_class;
+static jclass float_class;
+static jmethodID Float_floatValue_methodID;
 
-jclass Double_class;
-jclass double_class;
-jmethodID Double_doubleValue_methodID;
+static jclass Double_class;
+static jclass double_class;
+static jmethodID Double_doubleValue_methodID;
 
-jmethodID Method_getDeclaringClass_methodID;
-jmethodID Method_getModifiers_methodID;
-jmethodID Method_getParameterTypes_methodID;
-jmethodID Method_isVarArgs_methodID;
-jmethodID Method_getReturnType_methodID;
+static jmethodID Method_getDeclaringClass_methodID;
+static jmethodID Method_getModifiers_methodID;
+static jmethodID Method_getParameterTypes_methodID;
+static jmethodID Method_isVarArgs_methodID;
+static jmethodID Method_getReturnType_methodID;
 
-jmethodID Field_getDeclaringClass_methodID;
-jmethodID Field_getModifiers_methodID;
-jmethodID Field_getType_methodID;
+static jmethodID Field_getDeclaringClass_methodID;
+static jmethodID Field_getModifiers_methodID;
+static jmethodID Field_getType_methodID;
 
+// -----------------------------------------------------------------------------------------------------------------
 
-// Pre-look-up classes and methods for primitive types and Class, and allocate new global refs for them so they can be used across JNI calls
+// Look up a class by name, and store a new global reference to it in *out. Returns false if the class could not
+// be found, leaving the pending exception in place for the caller to clear.
+static bool initGlobalClassRef(JNIEnv* env, const char* class_name, jclass* out) {
+    jclass local_ref = (*env)->FindClass(env, class_name);
+    if (!local_ref || thrown(env)) { return false; }
+    *out = (jclass) (*env)->NewGlobalRef(env, local_ref);
+    (*env)->DeleteLocalRef(env, local_ref);
+    return *out != NULL;
+}
+
+// Read the static TYPE field of a boxed primitive type class (e.g. Integer.TYPE), and store a new global
+// reference to the resulting primitive class (e.g. int.class) in *out. Returns false on failure, leaving any
+// pending exception in place for the caller to clear.
+static bool initGlobalPrimitiveClassRef(JNIEnv* env, jclass boxed_class, jclass* out) {
+    jfieldID type_fieldID = (*env)->GetStaticFieldID(env, boxed_class, "TYPE", "Ljava/lang/Class;");
+    if (!type_fieldID || thrown(env)) { return false; }
+    jobject local_ref = (*env)->GetStaticObjectField(env, boxed_class, type_fieldID);
+    if (!local_ref || thrown(env)) { return false; }
+    *out = (jclass) (*env)->NewGlobalRef(env, local_ref);
+    (*env)->DeleteLocalRef(env, local_ref);
+    return *out != NULL;
+}
+
+// Look up an instance method, and store its method id in *out. Returns false on failure, leaving any pending
+// exception in place for the caller to clear.
+static bool initMethodID(JNIEnv* env, jclass cls, const char* method_name, const char* sig, jmethodID* out) {
+    *out = (*env)->GetMethodID(env, cls, method_name, sig);
+    return *out != NULL && !thrown(env);
+}
+
+// Look up a boxed primitive type class, the corresponding primitive type class, and the boxed type's
+// xxxValue() method. Returns false on failure, leaving any pending exception in place for the caller to clear.
+static bool initBoxedType(JNIEnv* env, const char* boxed_class_name, jclass* boxed_class_out,
+        jclass* primitive_class_out, const char* value_method_name, const char* value_method_sig,
+        jmethodID* value_methodID_out) {
+    return initGlobalClassRef(env, boxed_class_name, boxed_class_out)
+            && initGlobalPrimitiveClassRef(env, *boxed_class_out, primitive_class_out)
+            && initMethodID(env, *boxed_class_out, value_method_name, value_method_sig, value_methodID_out);
+}
+
+// Pre-look-up classes and methods for primitive types and Class, and allocate new global refs for them so they
+// can be used across JNI calls
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     JNIEnv* env = NULL;
-    if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_1) != JNI_OK) {
+    if ((*vm)->GetEnv(vm, (void**) &env, NARCISSUS_JNI_VERSION) != JNI_OK || env == NULL) {
         return -1;
     }
 
-    Class_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Class"));
-    if (thrown(env)) { return -1; }
-    Class_isArray_methodID = (*env)->GetMethodID(env, Class_class, "isArray", "()Z");
-    if (thrown(env)) { return -1; }
-    Class_getComponentType_methodID = (*env)->GetMethodID(env, Class_class, "getComponentType", "()Ljava/lang/Class;");
-    if (thrown(env)) { return -1; }
-    Class_getName_methodID = (*env)->GetMethodID(env, Class_class, "getName", "()Ljava/lang/String;");
-    if (thrown(env)) { return -1; }
-    Class_isPrimitive_methodID = (*env)->GetMethodID(env, Class_class, "isPrimitive", "()Z");
-    if (thrown(env)) { return -1; }
-    Class_getModifiers_methodID = (*env)->GetMethodID(env, Class_class, "getModifiers", "()I");
-    if (thrown(env)) { return -1; }
+    jclass Void_class = NULL;
+    jclass Method_class = NULL;
+    jclass Field_class = NULL;
+    bool ok = initGlobalClassRef(env, "java/lang/Class", &Class_class)
+            && initMethodID(env, Class_class, "isArray", "()Z", &Class_isArray_methodID)
+            && initMethodID(env, Class_class, "getComponentType", "()Ljava/lang/Class;",
+                    &Class_getComponentType_methodID)
+            && initMethodID(env, Class_class, "isPrimitive", "()Z", &Class_isPrimitive_methodID)
+            && initMethodID(env, Class_class, "getModifiers", "()I", &Class_getModifiers_methodID)
 
-    jclass Void_class = (*env)->FindClass(env, "java/lang/Void");
-    if (thrown(env)) { return -1; }
-    void_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Void_class, (*env)->GetStaticFieldID(env, Void_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    
-    Integer_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Integer"));
-    if (thrown(env)) { return -1; }
-    int_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Integer_class, (*env)->GetStaticFieldID(env, Integer_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    Integer_intValue_methodID = (*env)->GetMethodID(env, Integer_class, "intValue", "()I");
-    if (thrown(env)) { return -1; }
+            && initGlobalClassRef(env, "java/lang/Void", &Void_class)
+            && initGlobalPrimitiveClassRef(env, Void_class, &void_class)
 
-    Long_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Long"));
-    if (thrown(env)) { return -1; }
-    long_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Long_class, (*env)->GetStaticFieldID(env, Long_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    Long_longValue_methodID = (*env)->GetMethodID(env, Long_class, "longValue", "()J");
-    if (thrown(env)) { return -1; }
+            && initBoxedType(env, "java/lang/Integer", &Integer_class, &int_class, "intValue", "()I",
+                    &Integer_intValue_methodID)
+            && initBoxedType(env, "java/lang/Long", &Long_class, &long_class, "longValue", "()J",
+                    &Long_longValue_methodID)
+            && initBoxedType(env, "java/lang/Short", &Short_class, &short_class, "shortValue", "()S",
+                    &Short_shortValue_methodID)
+            && initBoxedType(env, "java/lang/Character", &Character_class, &char_class, "charValue", "()C",
+                    &Character_charValue_methodID)
+            && initBoxedType(env, "java/lang/Boolean", &Boolean_class, &boolean_class, "booleanValue", "()Z",
+                    &Boolean_booleanValue_methodID)
+            && initBoxedType(env, "java/lang/Byte", &Byte_class, &byte_class, "byteValue", "()B",
+                    &Byte_byteValue_methodID)
+            && initBoxedType(env, "java/lang/Float", &Float_class, &float_class, "floatValue", "()F",
+                    &Float_floatValue_methodID)
+            && initBoxedType(env, "java/lang/Double", &Double_class, &double_class, "doubleValue", "()D",
+                    &Double_doubleValue_methodID)
 
-    Short_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Short"));
-    if (thrown(env)) { return -1; }
-    short_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Short_class, (*env)->GetStaticFieldID(env, Short_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    Short_shortValue_methodID = (*env)->GetMethodID(env, Short_class, "shortValue", "()S");
-    if (thrown(env)) { return -1; }
+            && initGlobalClassRef(env, "java/lang/reflect/Method", &Method_class)
+            && initMethodID(env, Method_class, "getDeclaringClass", "()Ljava/lang/Class;",
+                    &Method_getDeclaringClass_methodID)
+            && initMethodID(env, Method_class, "getModifiers", "()I", &Method_getModifiers_methodID)
+            && initMethodID(env, Method_class, "getParameterTypes", "()[Ljava/lang/Class;",
+                    &Method_getParameterTypes_methodID)
+            && initMethodID(env, Method_class, "isVarArgs", "()Z", &Method_isVarArgs_methodID)
+            && initMethodID(env, Method_class, "getReturnType", "()Ljava/lang/Class;",
+                    &Method_getReturnType_methodID)
 
-    Character_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Character"));
-    if (thrown(env)) { return -1; }
-    char_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Character_class, (*env)->GetStaticFieldID(env, Character_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    Character_charValue_methodID = (*env)->GetMethodID(env, Character_class, "charValue", "()C");
-    if (thrown(env)) { return -1; }
+            && initGlobalClassRef(env, "java/lang/reflect/Field", &Field_class)
+            && initMethodID(env, Field_class, "getDeclaringClass", "()Ljava/lang/Class;",
+                    &Field_getDeclaringClass_methodID)
+            && initMethodID(env, Field_class, "getModifiers", "()I", &Field_getModifiers_methodID)
+            && initMethodID(env, Field_class, "getType", "()Ljava/lang/Class;", &Field_getType_methodID);
 
-    Boolean_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Boolean"));
-    if (thrown(env)) { return -1; }
-    boolean_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Boolean_class, (*env)->GetStaticFieldID(env, Boolean_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    Boolean_booleanValue_methodID = (*env)->GetMethodID(env, Boolean_class, "booleanValue", "()Z");
-    if (thrown(env)) { return -1; }
+    // Void, Method and Field are only needed during initialization
+    if (Void_class) { (*env)->DeleteGlobalRef(env, Void_class); }
+    if (Method_class) { (*env)->DeleteGlobalRef(env, Method_class); }
+    if (Field_class) { (*env)->DeleteGlobalRef(env, Field_class); }
 
-    Byte_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Byte"));
-    if (thrown(env)) { return -1; }
-    byte_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Byte_class, (*env)->GetStaticFieldID(env, Byte_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    Byte_byteValue_methodID = (*env)->GetMethodID(env, Byte_class, "byteValue", "()B");
-    if (thrown(env)) { return -1; }
-
-    Float_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Float"));
-    if (thrown(env)) { return -1; }
-    float_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Float_class, (*env)->GetStaticFieldID(env, Float_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    Float_floatValue_methodID = (*env)->GetMethodID(env, Float_class, "floatValue", "()F");
-    if (thrown(env)) { return -1; }
-
-    Double_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/Double"));
-    if (thrown(env)) { return -1; }
-    double_class = (*env)->NewGlobalRef(env, (*env)->GetStaticObjectField(env, Double_class, (*env)->GetStaticFieldID(env, Double_class, "TYPE", "Ljava/lang/Class;")));
-    if (thrown(env)) { return -1; }
-    Double_doubleValue_methodID = (*env)->GetMethodID(env, Double_class, "doubleValue", "()D");
-    if (thrown(env)) { return -1; }
-    
-    jclass Method_class = (*env)->FindClass(env, "java/lang/reflect/Method");
-    if (thrown(env)) { return -1; }
-    Method_getDeclaringClass_methodID = (*env)->GetMethodID(env, Method_class, "getDeclaringClass", "()Ljava/lang/Class;");
-    if (thrown(env)) { return -1; }
-    Method_getModifiers_methodID = (*env)->GetMethodID(env, Method_class, "getModifiers", "()I");
-    if (thrown(env)) { return -1; }
-    Method_getParameterTypes_methodID = (*env)->GetMethodID(env, Method_class, "getParameterTypes", "()[Ljava/lang/Class;");
-    if (thrown(env)) { return -1; }
-    Method_isVarArgs_methodID = (*env)->GetMethodID(env, Method_class, "isVarArgs", "()Z");
-    if (thrown(env)) { return -1; }
-    Method_getReturnType_methodID = (*env)->GetMethodID(env, Method_class, "getReturnType", "()Ljava/lang/Class;");
-    if (thrown(env)) { return -1; }
-    
-    jclass Field_class = (*env)->FindClass(env, "java/lang/reflect/Field");
-    if (thrown(env)) { return -1; }
-    Field_getDeclaringClass_methodID = (*env)->GetMethodID(env, Field_class, "getDeclaringClass", "()Ljava/lang/Class;");
-    if (thrown(env)) { return -1; }
-    Field_getModifiers_methodID = (*env)->GetMethodID(env, Field_class, "getModifiers", "()I");
-    if (thrown(env)) { return -1; }
-    Field_getType_methodID = (*env)->GetMethodID(env, Field_class, "getType", "()Ljava/lang/Class;");
-    if (thrown(env)) { return -1; }
-    
-    return JNI_VERSION_1_1;
+    if (!ok) {
+        // Returning from JNI_OnLoad with an exception pending is not permitted -- the JVM reports the failed
+        // return value as an UnsatisfiedLinkError instead
+        if (thrown(env)) { (*env)->ExceptionClear(env); }
+        return -1;
+    }
+    return NARCISSUS_JNI_VERSION;
 }
 
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved) {
     JNIEnv* env = NULL;
-    (*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_1);
+    if ((*vm)->GetEnv(vm, (void**) &env, NARCISSUS_JNI_VERSION) != JNI_OK || env == NULL) {
+        // The calling thread is not attached to the JVM, so the global refs cannot be deleted. They are
+        // released anyway when the JVM terminates.
+        return;
+    }
 
-    (*env)->DeleteGlobalRef(env, Class_class);
-    
-    (*env)->DeleteGlobalRef(env, void_class);
-
-    (*env)->DeleteGlobalRef(env, Integer_class);
-    (*env)->DeleteGlobalRef(env, int_class);
-
-    (*env)->DeleteGlobalRef(env, Long_class);
-    (*env)->DeleteGlobalRef(env, long_class);
-
-    (*env)->DeleteGlobalRef(env, Short_class);
-    (*env)->DeleteGlobalRef(env, short_class);
-
-    (*env)->DeleteGlobalRef(env, Character_class);
-    (*env)->DeleteGlobalRef(env, char_class);
-
-    (*env)->DeleteGlobalRef(env, Boolean_class);
-    (*env)->DeleteGlobalRef(env, boolean_class);
-
-    (*env)->DeleteGlobalRef(env, Byte_class);
-    (*env)->DeleteGlobalRef(env, byte_class);
-
-    (*env)->DeleteGlobalRef(env, Float_class);
-    (*env)->DeleteGlobalRef(env, float_class);
-
-    (*env)->DeleteGlobalRef(env, Double_class);
-    (*env)->DeleteGlobalRef(env, double_class);
+    jclass* global_refs[] = { &Class_class, &void_class, &Integer_class, &int_class, &Long_class, &long_class,
+        &Short_class, &short_class, &Character_class, &char_class, &Boolean_class, &boolean_class, &Byte_class,
+        &byte_class, &Float_class, &float_class, &Double_class, &double_class };
+    for (size_t i = 0; i < sizeof(global_refs) / sizeof(global_refs[0]); i++) {
+        if (*global_refs[i]) {
+            (*env)->DeleteGlobalRef(env, *global_refs[i]);
+            *global_refs[i] = NULL;
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------------------------------------------
 
-// Utility functions
+// Exception throwing
 
-void printClassName(JNIEnv* env, jclass cls) {
-    jstring strObj = (jstring) (*env)->CallObjectMethod(env, cls, Class_getName_methodID);
-    const char* str = (*env)->GetStringUTFChars(env, strObj, NULL);
-    printf("%s\n", str);
-    (*env)->ReleaseStringUTFChars(env, strObj, str);
-}
-
-void throwIllegalArgumentException(JNIEnv* env, char* msg) {
-    jclass cls = (*env)->FindClass(env, "java/lang/IllegalArgumentException");
+static void throwException(JNIEnv* env, const char* exception_class_name, const char* msg) {
+    jclass cls = (*env)->FindClass(env, exception_class_name);
     if (cls) {
         (*env)->ThrowNew(env, cls, msg);
+        (*env)->DeleteLocalRef(env, cls);
     }
 }
 
-void throwNullPointerException(JNIEnv* env, char* msg) {
-    jclass cls = (*env)->FindClass(env, "java/lang/NullPointerException");
-    if (cls) {
-        (*env)->ThrowNew(env, cls, msg);
-    }
+static void throwIllegalArgumentException(JNIEnv* env, const char* msg) {
+    throwException(env, "java/lang/IllegalArgumentException", msg);
 }
 
-void throwInstantiationException(JNIEnv* env, char* msg) {
-    jclass cls = (*env)->FindClass(env, "java/lang/InstantiationException");
-    if (cls) {
-        (*env)->ThrowNew(env, cls, msg);
-    }
+static void throwNullPointerException(JNIEnv* env, const char* msg) {
+    throwException(env, "java/lang/NullPointerException", msg);
 }
 
-void throwNoSuchMethodException(JNIEnv* env, char* msg) {
-    jclass cls = (*env)->FindClass(env, "java/lang/NoSuchMethodException");
-    if (cls) {
-        (*env)->ThrowNew(env, cls, msg);
-    }
+static void throwInstantiationException(JNIEnv* env, const char* msg) {
+    throwException(env, "java/lang/InstantiationException", msg);
 }
 
-void throwNoSuchFieldException(JNIEnv* env, char* msg) {
-    jclass cls = (*env)->FindClass(env, "java/lang/NoSuchFieldException");
-    if (cls) {
-        (*env)->ThrowNew(env, cls, msg);
-    }
+// -----------------------------------------------------------------------------------------------------------------
+
+// Primitive types
+
+// The primitive types, in a fixed order, used to index the tables below. PRIM_NONE stands for "not a primitive
+// type", i.e. a reference type.
+typedef enum {
+    PRIM_NONE = 0,
+    PRIM_BOOLEAN,
+    PRIM_BYTE,
+    PRIM_CHAR,
+    PRIM_SHORT,
+    PRIM_INT,
+    PRIM_LONG,
+    PRIM_FLOAT,
+    PRIM_DOUBLE,
+    NUM_PRIM_KINDS
+} prim_kind;
+
+// The name of the boxed type corresponding to each prim_kind, for use in exception messages
+static const char* BOXED_TYPE_NAME[NUM_PRIM_KINDS] = { "", "Boolean", "Byte", "Character", "Short", "Integer",
+    "Long", "Float", "Double" };
+
+// For each prim_kind, the set of prim_kinds that a value of that type can be converted to by widening primitive
+// conversion (JLS 5.1.2), including the identity conversion. Note that byte does not widen to char, and char
+// does not widen to short or byte.
+static const int WIDENS_TO[NUM_PRIM_KINDS] = {
+    /* PRIM_NONE    */ 0,
+    /* PRIM_BOOLEAN */ (1 << PRIM_BOOLEAN),
+    /* PRIM_BYTE    */ (1 << PRIM_BYTE) | (1 << PRIM_SHORT) | (1 << PRIM_INT) | (1 << PRIM_LONG)
+                       | (1 << PRIM_FLOAT) | (1 << PRIM_DOUBLE),
+    /* PRIM_CHAR    */ (1 << PRIM_CHAR) | (1 << PRIM_INT) | (1 << PRIM_LONG) | (1 << PRIM_FLOAT)
+                       | (1 << PRIM_DOUBLE),
+    /* PRIM_SHORT   */ (1 << PRIM_SHORT) | (1 << PRIM_INT) | (1 << PRIM_LONG) | (1 << PRIM_FLOAT)
+                       | (1 << PRIM_DOUBLE),
+    /* PRIM_INT     */ (1 << PRIM_INT) | (1 << PRIM_LONG) | (1 << PRIM_FLOAT) | (1 << PRIM_DOUBLE),
+    /* PRIM_LONG    */ (1 << PRIM_LONG) | (1 << PRIM_FLOAT) | (1 << PRIM_DOUBLE),
+    /* PRIM_FLOAT   */ (1 << PRIM_FLOAT) | (1 << PRIM_DOUBLE),
+    /* PRIM_DOUBLE  */ (1 << PRIM_DOUBLE)
+};
+
+// Map a primitive type class (e.g. int.class) to its prim_kind, or PRIM_NONE if cls is a reference type
+static prim_kind primKindOfClass(JNIEnv* env, jclass cls) {
+    if (cls == NULL) { return PRIM_NONE; }
+    if ((*env)->IsSameObject(env, cls, int_class)) { return PRIM_INT; }
+    if ((*env)->IsSameObject(env, cls, long_class)) { return PRIM_LONG; }
+    if ((*env)->IsSameObject(env, cls, short_class)) { return PRIM_SHORT; }
+    if ((*env)->IsSameObject(env, cls, char_class)) { return PRIM_CHAR; }
+    if ((*env)->IsSameObject(env, cls, boolean_class)) { return PRIM_BOOLEAN; }
+    if ((*env)->IsSameObject(env, cls, byte_class)) { return PRIM_BYTE; }
+    if ((*env)->IsSameObject(env, cls, float_class)) { return PRIM_FLOAT; }
+    if ((*env)->IsSameObject(env, cls, double_class)) { return PRIM_DOUBLE; }
+    return PRIM_NONE;
 }
 
+// Map a boxed primitive type class (e.g. Integer.class) to the prim_kind it boxes, or PRIM_NONE if cls is not a
+// boxed primitive type
+static prim_kind boxedKindOfClass(JNIEnv* env, jclass cls) {
+    if (cls == NULL) { return PRIM_NONE; }
+    if ((*env)->IsSameObject(env, cls, Integer_class)) { return PRIM_INT; }
+    if ((*env)->IsSameObject(env, cls, Long_class)) { return PRIM_LONG; }
+    if ((*env)->IsSameObject(env, cls, Short_class)) { return PRIM_SHORT; }
+    if ((*env)->IsSameObject(env, cls, Character_class)) { return PRIM_CHAR; }
+    if ((*env)->IsSameObject(env, cls, Boolean_class)) { return PRIM_BOOLEAN; }
+    if ((*env)->IsSameObject(env, cls, Byte_class)) { return PRIM_BYTE; }
+    if ((*env)->IsSameObject(env, cls, Float_class)) { return PRIM_FLOAT; }
+    if ((*env)->IsSameObject(env, cls, Double_class)) { return PRIM_DOUBLE; }
+    return PRIM_NONE;
+}
 
-bool argIsNull(JNIEnv* env, jobject obj) {
+// -----------------------------------------------------------------------------------------------------------------
+
+// Argument checks. Each of these returns false with a Java exception pending if the check failed.
+
+static bool argIsNull(JNIEnv* env, jobject obj) {
     if (!obj) {
         throwNullPointerException(env, "Argument cannot be null");
         return true;
@@ -284,39 +347,34 @@ bool argIsNull(JNIEnv* env, jobject obj) {
     return false;
 }
 
-bool checkFieldStaticModifier(JNIEnv* env, jobject field, bool expectStatic) {
+static bool checkFieldStaticModifier(JNIEnv* env, jobject field, bool expectStatic) {
     jint mods = (*env)->CallIntMethod(env, field, Field_getModifiers_methodID);
-    if (thrown(env)) {
-        throwIllegalArgumentException(env, "Could not read field modifiers");
-        return false;
-    }
-    if (((mods & 8) ? 1 : 0) != (expectStatic ? 1 : 0)) {
+    if (thrown(env)) { return false; }
+    if (((mods & MODIFIER_STATIC) != 0) != expectStatic) {
         throwIllegalArgumentException(env, expectStatic ? "Expected static field" : "Expected non-static field");
         return false;
     }
     return true;
 }
 
-bool checkMethodStaticModifier(JNIEnv* env, jobject method, bool expectStatic) {
+static bool checkMethodStaticModifier(JNIEnv* env, jobject method, bool expectStatic) {
     jint mods = (*env)->CallIntMethod(env, method, Method_getModifiers_methodID);
-    if (thrown(env)) {
-        throwIllegalArgumentException(env, "Could not read method modifiers");
-        return false;
-    }
-    if (((mods & 8) ? 1 : 0) != (expectStatic ? 1 : 0)) {
+    if (thrown(env)) { return false; }
+    if (((mods & MODIFIER_STATIC) != 0) != expectStatic) {
         throwIllegalArgumentException(env, expectStatic ? "Expected static method" : "Expected non-static method");
         return false;
     }
     return true;
 }
 
-bool checkFieldReceiver(JNIEnv* env, jobject obj, jobject field) {
+static bool checkFieldReceiver(JNIEnv* env, jobject obj, jobject field) {
     jclass cls = (*env)->GetObjectClass(env, obj);
     if (thrown(env)) { return false; }
-    jclass declaringClass = (*env)->CallObjectMethod(env, field, Field_getDeclaringClass_methodID);
-    if (thrown(env)) { return false; }
+    jclass declaringClass = (jclass) (*env)->CallObjectMethod(env, field, Field_getDeclaringClass_methodID);
+    if (thrown(env)) { (*env)->DeleteLocalRef(env, cls); return false; }
     jboolean assignable = (*env)->IsAssignableFrom(env, cls, declaringClass);
-    if (thrown(env)) { return false; }
+    (*env)->DeleteLocalRef(env, cls);
+    (*env)->DeleteLocalRef(env, declaringClass);
     if (!assignable) {
         throwIllegalArgumentException(env, "Object class does not match declaring class of field");
         return false;
@@ -324,13 +382,14 @@ bool checkFieldReceiver(JNIEnv* env, jobject obj, jobject field) {
     return true;
 }
 
-bool checkMethodReceiver(JNIEnv* env, jobject obj, jobject method) {
+static bool checkMethodReceiver(JNIEnv* env, jobject obj, jobject method) {
     jclass cls = (*env)->GetObjectClass(env, obj);
     if (thrown(env)) { return false; }
-    jclass declaringClass = (*env)->CallObjectMethod(env, method, Method_getDeclaringClass_methodID);
-    if (thrown(env)) { return false; }
+    jclass declaringClass = (jclass) (*env)->CallObjectMethod(env, method, Method_getDeclaringClass_methodID);
+    if (thrown(env)) { (*env)->DeleteLocalRef(env, cls); return false; }
     jboolean assignable = (*env)->IsAssignableFrom(env, cls, declaringClass);
-    if (thrown(env)) { return false; }
+    (*env)->DeleteLocalRef(env, cls);
+    (*env)->DeleteLocalRef(env, declaringClass);
     if (!assignable) {
         throwIllegalArgumentException(env, "Object class does not match declaring class of method");
         return false;
@@ -338,11 +397,11 @@ bool checkMethodReceiver(JNIEnv* env, jobject obj, jobject method) {
     return true;
 }
 
-bool checkPrimitiveMethodReturnType(JNIEnv* env, jobject method, jclass primitive_class) {
-    jclass return_type = (*env)->CallObjectMethod(env, method, Method_getReturnType_methodID);
+static bool checkPrimitiveMethodReturnType(JNIEnv* env, jobject method, jclass primitive_class) {
+    jclass return_type = (jclass) (*env)->CallObjectMethod(env, method, Method_getReturnType_methodID);
     if (thrown(env)) { return false; }
     jboolean is_correct_return_type = (*env)->IsSameObject(env, return_type, primitive_class);
-    if (thrown(env)) { return false; }
+    (*env)->DeleteLocalRef(env, return_type);
     if (!is_correct_return_type) {
         throwIllegalArgumentException(env, "Return type of method does not match primitive method invocation type");
         return false;
@@ -350,39 +409,66 @@ bool checkPrimitiveMethodReturnType(JNIEnv* env, jobject method, jclass primitiv
     return true;
 }
 
-bool checkMethodReturnTypeNotVoidOrPrimitive(JNIEnv* env, jobject method) {
-    jclass return_type = (*env)->CallObjectMethod(env, method, Method_getReturnType_methodID);
+static bool checkMethodReturnTypeNotVoidOrPrimitive(JNIEnv* env, jobject method) {
+    jclass return_type = (jclass) (*env)->CallObjectMethod(env, method, Method_getReturnType_methodID);
     if (thrown(env)) { return false; }
     jboolean is_void_return_type = (*env)->IsSameObject(env, return_type, void_class);
-    if (thrown(env)) { return false; }
+    prim_kind return_kind = primKindOfClass(env, return_type);
+    (*env)->DeleteLocalRef(env, return_type);
     if (is_void_return_type) {
-        throwIllegalArgumentException(env, "Return type of method is void, but tried to invoke as method with Object return type");
+        throwIllegalArgumentException(env,
+                "Return type of method is void, but tried to invoke as method with Object return type");
         return false;
     }
-    jboolean is_primitive_return_type = (*env)->IsSameObject(env, return_type, int_class)
-            || (*env)->IsSameObject(env, return_type, long_class)
-            || (*env)->IsSameObject(env, return_type, short_class)
-            || (*env)->IsSameObject(env, return_type, char_class)
-            || (*env)->IsSameObject(env, return_type, boolean_class)
-            || (*env)->IsSameObject(env, return_type, byte_class)
-            || (*env)->IsSameObject(env, return_type, float_class)
-            || (*env)->IsSameObject(env, return_type, double_class);
-    if (thrown(env)) { return false; }
-    if (is_primitive_return_type) {
-        throwIllegalArgumentException(env, "Return type of method is of primitive type, but tried to invoke as method with Object return type");
+    if (return_kind != PRIM_NONE) {
+        throwIllegalArgumentException(env,
+                "Return type of method is of primitive type, but tried to invoke as method with Object return type");
         return false;
     }
     return true;
 }
 
-bool checkFieldValType(JNIEnv* env, jobject field, jobject val) {
+// Check that the declared type of a field is exactly the given primitive type. Without this check, a typed
+// accessor such as getIntField() called on a field of a different type reads or writes the wrong number of
+// bytes at the wrong offset, which corrupts the heap or crashes the JVM.
+static bool checkFieldPrimitiveType(JNIEnv* env, jobject field, jclass primitive_class) {
+    jclass field_type = (jclass) (*env)->CallObjectMethod(env, field, Field_getType_methodID);
+    if (thrown(env)) { return false; }
+    jboolean is_correct_type = (*env)->IsSameObject(env, field_type, primitive_class);
+    (*env)->DeleteLocalRef(env, field_type);
+    if (!is_correct_type) {
+        throwIllegalArgumentException(env, "Field type does not match primitive field accessor type");
+        return false;
+    }
+    return true;
+}
+
+// Check that the declared type of a field is a reference type, for the Object-typed field accessors
+static bool checkFieldTypeIsReference(JNIEnv* env, jobject field) {
+    jclass field_type = (jclass) (*env)->CallObjectMethod(env, field, Field_getType_methodID);
+    if (thrown(env)) { return false; }
+    jboolean is_primitive = (*env)->CallBooleanMethod(env, field_type, Class_isPrimitive_methodID);
+    (*env)->DeleteLocalRef(env, field_type);
+    if (thrown(env)) { return false; }
+    if (is_primitive) {
+        throwIllegalArgumentException(env,
+                "Field type is of primitive type, but tried to access as field with Object type");
+        return false;
+    }
+    return true;
+}
+
+// Check that a value is assignable to a field of reference type. A null value is assignable to any field of
+// reference type -- checkFieldTypeIsReference() has already rejected fields of primitive type.
+static bool checkFieldValType(JNIEnv* env, jobject field, jobject val) {
     if (val != NULL) {
         jclass valCls = (*env)->GetObjectClass(env, val);
         if (thrown(env)) { return false; }
-        jclass fieldType = (*env)->CallObjectMethod(env, field, Field_getType_methodID);
-        if (thrown(env)) { return false; }
+        jclass fieldType = (jclass) (*env)->CallObjectMethod(env, field, Field_getType_methodID);
+        if (thrown(env)) { (*env)->DeleteLocalRef(env, valCls); return false; }
         jboolean assignable = (*env)->IsAssignableFrom(env, valCls, fieldType);
-        if (thrown(env)) { return false; }
+        (*env)->DeleteLocalRef(env, valCls);
+        (*env)->DeleteLocalRef(env, fieldType);
         if (!assignable) {
             throwIllegalArgumentException(env, "Value cannot be assigned to a field of this type");
             return false;
@@ -393,122 +479,266 @@ bool checkFieldValType(JNIEnv* env, jobject field, jobject val) {
 
 // -----------------------------------------------------------------------------------------------------------------
 
-// Unbox a jobjectArray of method invocation args into a jvalue array. Returns 0 if an exception was thrown, or 1 if unboxing succeeded.
-int unbox(JNIEnv *env, jobject method, jobjectArray args, jsize num_args, jvalue* arg_jvalues) {
-    // Get parameter types of method
-    jobject parameterTypes = (*env)->CallObjectMethod(env, method, Method_getParameterTypes_methodID);
-    if (thrown(env)) { return 0; }
-    jsize num_params = (*env)->GetArrayLength(env, parameterTypes);
-    if (thrown(env)) { return 0; }
-    jboolean is_varargs = (*env)->CallBooleanMethod(env, method, Method_isVarArgs_methodID);
-    if (thrown(env)) { return 0; }
-    jclass varargs_elt_type = NULL;
-    if (is_varargs && num_params > 0) {
-        jclass varargs_arr_type = (*env)->GetObjectArrayElement(env, parameterTypes, num_params - 1);
-        if (thrown(env)) { return 0; }
-        varargs_elt_type = (*env)->CallObjectMethod(env, varargs_arr_type, Class_getComponentType_methodID);
-        if (thrown(env)) { return 0; }
+// Unboxing of method invocation arguments
+
+// Unbox a single argument into a jvalue of the given primitive type, applying widening primitive conversion
+// (JLS 5.1.2) if the boxed type of the argument is narrower than the parameter type. Returns false with a Java
+// exception pending if the argument is null, or is not of a type that can be converted to the parameter type.
+static bool unboxArg(JNIEnv* env, jobject arg, prim_kind target_kind, jvalue* out) {
+    char msg[MAX_MSG_LEN];
+    if (arg == NULL) {
+        snprintf(msg, sizeof(msg), "Tried to unbox a null argument; expected %s", BOXED_TYPE_NAME[target_kind]);
+        throwIllegalArgumentException(env, msg);
+        return false;
     }
+    jclass arg_type = (*env)->GetObjectClass(env, arg);
+    if (thrown(env)) { return false; }
+    prim_kind arg_kind = boxedKindOfClass(env, arg_type);
+    (*env)->DeleteLocalRef(env, arg_type);
+    if (arg_kind == PRIM_NONE || (WIDENS_TO[arg_kind] & (1 << target_kind)) == 0) {
+        snprintf(msg, sizeof(msg), "Tried to unbox arg of wrong type; expected %s", BOXED_TYPE_NAME[target_kind]);
+        throwIllegalArgumentException(env, msg);
+        return false;
+    }
+
+    // Read the value out of the box. Integral types (and boolean) are read into a jlong, and floating point
+    // types into a jdouble -- the widening table guarantees that the target type can represent the result.
+    jlong long_val = 0;
+    jdouble double_val = 0.0;
+    switch (arg_kind) {
+    case PRIM_BOOLEAN:
+        long_val = (*env)->CallBooleanMethod(env, arg, Boolean_booleanValue_methodID) ? 1 : 0;
+        break;
+    case PRIM_BYTE:
+        long_val = (*env)->CallByteMethod(env, arg, Byte_byteValue_methodID);
+        break;
+    case PRIM_CHAR:
+        long_val = (*env)->CallCharMethod(env, arg, Character_charValue_methodID);
+        break;
+    case PRIM_SHORT:
+        long_val = (*env)->CallShortMethod(env, arg, Short_shortValue_methodID);
+        break;
+    case PRIM_INT:
+        long_val = (*env)->CallIntMethod(env, arg, Integer_intValue_methodID);
+        break;
+    case PRIM_LONG:
+        long_val = (*env)->CallLongMethod(env, arg, Long_longValue_methodID);
+        break;
+    case PRIM_FLOAT:
+        double_val = (*env)->CallFloatMethod(env, arg, Float_floatValue_methodID);
+        break;
+    default:
+        double_val = (*env)->CallDoubleMethod(env, arg, Double_doubleValue_methodID);
+        break;
+    }
+    if (thrown(env)) { return false; }
+    bool arg_is_floating_point = arg_kind == PRIM_FLOAT || arg_kind == PRIM_DOUBLE;
+
+    // Convert the value to the parameter type
+    switch (target_kind) {
+    case PRIM_BOOLEAN: out->z = (jboolean) (long_val != 0); break;
+    case PRIM_BYTE: out->b = (jbyte) long_val; break;
+    case PRIM_CHAR: out->c = (jchar) long_val; break;
+    case PRIM_SHORT: out->s = (jshort) long_val; break;
+    case PRIM_INT: out->i = (jint) long_val; break;
+    case PRIM_LONG: out->j = long_val; break;
+    case PRIM_FLOAT: out->f = arg_is_floating_point ? (jfloat) double_val : (jfloat) long_val; break;
+    default: out->d = arg_is_floating_point ? double_val : (jdouble) long_val; break;
+    }
+    return true;
+}
+
+// Pack the trailing arguments of a varargs invocation into an array of the declared varargs element type, and
+// store the array in *out. Returns false with a Java exception pending if any argument cannot be converted to
+// the varargs element type.
+static bool packVarargs(JNIEnv* env, jobjectArray args, jsize num_non_varargs_params, jsize num_varargs_args,
+        jclass varargs_elt_type, jvalue* out) {
+    prim_kind varargs_elt_kind = primKindOfClass(env, varargs_elt_type);
+
+// Pack the trailing args into a newly-allocated primitive array. The array elements are released on every
+// path out of the loop, with mode JNI_ABORT if unboxing failed, so that a copied array is not written back.
+#define UNBOX_VARARGS_CASE(_kind, _prim_type, _Prim_type, _jvalue_field) \
+    case _kind: { \
+        j ## _prim_type ## Array arr = (*env)->New ## _Prim_type ## Array(env, num_varargs_args); \
+        if (!arr) { return false; } \
+        out->l = arr; \
+        j ## _prim_type* elts = (*env)->Get ## _Prim_type ## ArrayElements(env, arr, NULL); \
+        if (!elts) { return false; } \
+        bool ok = true; \
+        for (jsize i = 0; i < num_varargs_args; i++) { \
+            jobject arg = (*env)->GetObjectArrayElement(env, args, i + num_non_varargs_params); \
+            if (thrown(env)) { ok = false; break; } \
+            jvalue val; \
+            ok = unboxArg(env, arg, _kind, &val); \
+            if (arg != NULL) { (*env)->DeleteLocalRef(env, arg); } \
+            if (!ok) { break; } \
+            elts[i] = val._jvalue_field; \
+        } \
+        (*env)->Release ## _Prim_type ## ArrayElements(env, arr, elts, ok ? 0 : JNI_ABORT); \
+        return ok; \
+    }
+
+    switch (varargs_elt_kind) {
+    UNBOX_VARARGS_CASE(PRIM_BOOLEAN, boolean, Boolean, z)
+    UNBOX_VARARGS_CASE(PRIM_BYTE, byte, Byte, b)
+    UNBOX_VARARGS_CASE(PRIM_CHAR, char, Char, c)
+    UNBOX_VARARGS_CASE(PRIM_SHORT, short, Short, s)
+    UNBOX_VARARGS_CASE(PRIM_INT, int, Int, i)
+    UNBOX_VARARGS_CASE(PRIM_LONG, long, Long, j)
+    UNBOX_VARARGS_CASE(PRIM_FLOAT, float, Float, f)
+    UNBOX_VARARGS_CASE(PRIM_DOUBLE, double, Double, d)
+    default:
+        break;
+    }
+#undef UNBOX_VARARGS_CASE
+
+    // The varargs element type is a reference type -- check that each trailing arg is assignable to it
+    jobjectArray arr = (*env)->NewObjectArray(env, num_varargs_args, varargs_elt_type, NULL);
+    if (!arr) { return false; }
+    out->l = arr;
+    for (jsize i = 0; i < num_varargs_args; i++) {
+        jobject arg = (*env)->GetObjectArrayElement(env, args, i + num_non_varargs_params);
+        if (thrown(env)) { return false; }
+        if (arg != NULL) {
+            jclass arg_type = (*env)->GetObjectClass(env, arg);
+            if (thrown(env)) { return false; }
+            jboolean assignable = (*env)->IsAssignableFrom(env, arg_type, varargs_elt_type);
+            (*env)->DeleteLocalRef(env, arg_type);
+            if (!assignable) {
+                throwIllegalArgumentException(env, "Tried to invoke function with varargs arg of incompatible type");
+                return false;
+            }
+        }
+        (*env)->SetObjectArrayElement(env, arr, i, arg);
+        if (arg != NULL) { (*env)->DeleteLocalRef(env, arg); }
+        if (thrown(env)) { return false; }
+    }
+    return true;
+}
+
+// Convert the args of a method invocation into a jvalue array, checking the arity of the call and the type of
+// each arg against the parameter types of the method. Returns false if a Java exception is pending.
+static bool unboxArgs(JNIEnv* env, jobjectArray parameterTypes, jsize num_params, bool is_varargs,
+        jobjectArray args, jsize num_args, jvalue* arg_jvalues) {
+    // A varargs method always has at least one parameter (the varargs array itself), but check defensively,
+    // since num_params is read from a Method object that the caller supplied
+    if (num_params == 0) { is_varargs = false; }
     jsize num_non_varargs_params = num_params - (is_varargs ? 1 : 0);
 
     // Check arg arity
     if ((!is_varargs && num_args != num_params) || (is_varargs && num_args < num_non_varargs_params)) {
         throwIllegalArgumentException(env, "Tried to invoke method with wrong number of arguments");
-        return 0;
+        return false;
     }
     jsize num_varargs_args = num_args - num_non_varargs_params;
-        
+
+    // Each arg of reference type has to stay reachable through a local reference until the method has been
+    // invoked, and the default local reference capacity is only 16
+    if ((*env)->EnsureLocalCapacity(env, num_params + LOCAL_REF_SLACK) != 0) { return false; }
+
     // Unbox non-varargs args
     for (jsize i = 0; i < num_non_varargs_params; i++) {
-        jobject param_type = (*env)->GetObjectArrayElement(env, parameterTypes, i);
-        if (thrown(env)) { return 0; }
+        jclass param_type = (jclass) (*env)->GetObjectArrayElement(env, parameterTypes, i);
+        if (thrown(env)) { return false; }
         jobject arg = (*env)->GetObjectArrayElement(env, args, i);
-        if (thrown(env)) { return 0; }
-        jclass arg_type = arg == NULL ? (jclass) NULL : (*env)->GetObjectClass(env, arg);
-        if (thrown(env)) { return 0; }
-
-#define TRY_UNBOX_ARG(_prim_type, _Prim_type, _Boxed_type, _jvalue_field) \
-        if ((*env)->IsSameObject(env, param_type, _prim_type ## _class)) { \
-            if (arg == NULL) { \
-                throwIllegalArgumentException(env, "Tried to unbox a null argument; expected " #_Boxed_type); \
-            } else if (!(*env)->IsSameObject(env, arg_type, _Boxed_type ## _class)) { \
-                throwIllegalArgumentException(env, "Tried to unbox arg of wrong type; expected " #_Boxed_type); \
-            } else { \
-                arg_jvalues[i]._jvalue_field = (*env)->Call ## _Prim_type ## Method(env, arg, _Boxed_type ## _ ## _prim_type ## Value_methodID); \
-            } \
-        }
-        TRY_UNBOX_ARG(int, Int, Integer, i)
-        else TRY_UNBOX_ARG(long, Long, Long, j)
-        else TRY_UNBOX_ARG(short, Short, Short, s)
-        else TRY_UNBOX_ARG(char, Char, Character, c)
-        else TRY_UNBOX_ARG(boolean, Boolean, Boolean, z)
-        else TRY_UNBOX_ARG(byte, Byte, Byte, b)
-        else TRY_UNBOX_ARG(float, Float, Float, f)
-        else TRY_UNBOX_ARG(double, Double, Double, d)
-        else {
-            // Parameter type is not primitive -- check if arg is assignable from the parameter type
-            if (arg != NULL && !(*env)->IsAssignableFrom(env, arg_type, param_type)) {
-                throwIllegalArgumentException(env, "Tried to invoke function with arg of incompatible type");
-            } else {
-                arg_jvalues[i].l = arg;
-            }
-        }
-        if (thrown(env)) { return 0; }
-    }
-    if (is_varargs) {
-        // Unbox varargs, if varargs_elt_type is primitive
-#define TRY_UNBOX_VARARGS(_prim_type, _Prim_type, _Boxed_type) \
-        if ((*env)->IsSameObject(env, varargs_elt_type, _prim_type ## _class)) { \
-            j ## _prim_type ## Array arr = (*env)->New ## _Prim_type ## Array(env, num_varargs_args); \
-            arg_jvalues[num_non_varargs_params].l = arr; \
-            if (thrown(env)) { return 0; } \
-            j ## _prim_type *elts = (*env)->Get ## _Prim_type ## ArrayElements(env, arr, NULL); \
-            if (!elts) { return 0; } \
-            for (jsize i = 0; i < num_varargs_args; i++) { \
-                jobject arg = (*env)->GetObjectArrayElement(env, args, i + num_non_varargs_params); \
-                if (thrown(env)) { return 0; } \
-                if (arg == NULL) { \
-                    throwIllegalArgumentException(env, "Tried to unbox a null argument"); \
-                    return 0; \
-                } \
-                jclass arg_type = (*env)->GetObjectClass(env, arg); \
-                if (thrown(env)) { return 0; } \
-                if (!(*env)->IsSameObject(env, arg_type, _Boxed_type ## _class)) { \
-                    throwIllegalArgumentException(env, "Tried to unbox arg of wrong type"); \
-                    return 0; \
-                } else { \
-                    elts[i] = (*env)->Call ## _Prim_type ## Method(env, arg, _Boxed_type ## _ ## _prim_type ## Value_methodID); \
-                } \
-            } \
-            (*env)->Release ## _Prim_type ## ArrayElements(env, arr, elts, 0); \
-        }
-        TRY_UNBOX_VARARGS(int, Int, Integer)
-        else TRY_UNBOX_VARARGS(long, Long, Long)
-        else TRY_UNBOX_VARARGS(short, Short, Short)
-        else TRY_UNBOX_VARARGS(char, Char, Character)
-        else TRY_UNBOX_VARARGS(boolean, Boolean, Boolean)
-        else TRY_UNBOX_VARARGS(byte, Byte, Byte)
-        else TRY_UNBOX_VARARGS(float, Float, Float)
-        else TRY_UNBOX_VARARGS(double, Double, Double)
-        else {
-            // varargs_elt_type is non-primitive -- check if each element of remaining args is assignable from varargs element type
-            jobjectArray arr = arg_jvalues[num_non_varargs_params].l = (*env)->NewObjectArray(env, num_varargs_args, varargs_elt_type, NULL);
-            if (thrown(env)) { return 0; }
-            for (jsize i = 0; i < num_varargs_args; i++) {
-                jobject arg = (*env)->GetObjectArrayElement(env, args, i + num_non_varargs_params);
-                if (thrown(env)) { return 0; }
-                jclass arg_type = arg == NULL ? (jclass) NULL : (*env)->GetObjectClass(env, arg);
-                if (thrown(env)) { return 0; }
-                if (arg != NULL && !(*env)->IsAssignableFrom(env, arg_type, varargs_elt_type)) {
-                    throwIllegalArgumentException(env, "Tried to invoke function with varargs arg of incompatible type");
-                } else {
-                    (*env)->SetObjectArrayElement(env, arr, i, arg);
+        if (thrown(env)) { return false; }
+        prim_kind param_kind = primKindOfClass(env, param_type);
+        if (param_kind != PRIM_NONE) {
+            bool ok = unboxArg(env, arg, param_kind, &arg_jvalues[i]);
+            if (arg != NULL) { (*env)->DeleteLocalRef(env, arg); }
+            (*env)->DeleteLocalRef(env, param_type);
+            if (!ok) { return false; }
+        } else {
+            if (arg != NULL) {
+                jclass arg_type = (*env)->GetObjectClass(env, arg);
+                if (thrown(env)) { return false; }
+                jboolean assignable = (*env)->IsAssignableFrom(env, arg_type, param_type);
+                (*env)->DeleteLocalRef(env, arg_type);
+                if (!assignable) {
+                    throwIllegalArgumentException(env, "Tried to invoke function with arg of incompatible type");
+                    return false;
                 }
-                if (thrown(env)) { return 0; }
+            }
+            (*env)->DeleteLocalRef(env, param_type);
+            // Keep the local reference to arg alive -- it is passed to the method as a jvalue
+            arg_jvalues[i].l = arg;
+        }
+    }
+    if (!is_varargs) {
+        return true;
+    }
+
+    // Get the declared type of the varargs parameter, and of its elements
+    jclass varargs_arr_type = (jclass) (*env)->GetObjectArrayElement(env, parameterTypes, num_params - 1);
+    if (thrown(env)) { return false; }
+    jclass varargs_elt_type = (jclass) (*env)->CallObjectMethod(env, varargs_arr_type,
+            Class_getComponentType_methodID);
+    if (thrown(env)) { (*env)->DeleteLocalRef(env, varargs_arr_type); return false; }
+    if (varargs_elt_type == NULL) {
+        // The last parameter of a varargs method is always an array type, so this cannot happen unless the
+        // caller supplied a Method object with an inconsistent isVarArgs() flag
+        (*env)->DeleteLocalRef(env, varargs_arr_type);
+        throwIllegalArgumentException(env, "Varargs parameter is not of array type");
+        return false;
+    }
+
+    // If a single trailing arg was passed, and it is already an array of the declared varargs type, then pass
+    // it through as-is rather than wrapping it in another array. This accepts args in the form produced by
+    // the Java compiler at a varargs call site, as well as in the pre-packed form that Method.invoke() takes.
+    bool packed = false;
+    bool ok = true;
+    if (num_varargs_args == 1) {
+        jobject arg = (*env)->GetObjectArrayElement(env, args, num_non_varargs_params);
+        if (thrown(env)) {
+            ok = false;
+        } else if (arg != NULL) {
+            jclass arg_type = (*env)->GetObjectClass(env, arg);
+            if (thrown(env)) {
+                ok = false;
+            } else {
+                jboolean assignable = (*env)->IsAssignableFrom(env, arg_type, varargs_arr_type);
+                (*env)->DeleteLocalRef(env, arg_type);
+                if (assignable) {
+                    // Keep the local reference to arg alive -- it is passed to the method as a jvalue
+                    arg_jvalues[num_non_varargs_params].l = arg;
+                    packed = true;
+                } else {
+                    (*env)->DeleteLocalRef(env, arg);
+                }
             }
         }
     }
-    return 1;
+    if (ok && !packed) {
+        ok = packVarargs(env, args, num_non_varargs_params, num_varargs_args, varargs_elt_type,
+                &arg_jvalues[num_non_varargs_params]);
+    }
+    (*env)->DeleteLocalRef(env, varargs_elt_type);
+    (*env)->DeleteLocalRef(env, varargs_arr_type);
+    return ok;
+}
+
+// Unbox a jobjectArray of method invocation args into a jvalue array. Returns false if a Java exception is
+// pending. arg_jvalues must have room for MAX_METHOD_PARAMS entries.
+static bool unbox(JNIEnv* env, jobject method, jobjectArray args, jsize num_args, jvalue* arg_jvalues) {
+    jobjectArray parameterTypes = (jobjectArray) (*env)->CallObjectMethod(env, method,
+            Method_getParameterTypes_methodID);
+    if (thrown(env)) { return false; }
+    bool ok = false;
+    jsize num_params = (*env)->GetArrayLength(env, parameterTypes);
+    if (!thrown(env)) {
+        if (num_params > MAX_METHOD_PARAMS) {
+            // Cannot happen for a method loaded from a valid classfile, but arg_jvalues is a fixed-size buffer
+            throwIllegalArgumentException(env, "Method has too many parameters");
+        } else {
+            jboolean is_varargs = (*env)->CallBooleanMethod(env, method, Method_isVarArgs_methodID);
+            if (!thrown(env)) {
+                ok = unboxArgs(env, parameterTypes, num_params, is_varargs ? true : false, args, num_args,
+                        arg_jvalues);
+            }
+        }
+    }
+    (*env)->DeleteLocalRef(env, parameterTypes);
+    return ok;
 }
 
 // -----------------------------------------------------------------------------------------------------------------
@@ -547,7 +777,7 @@ JNIEXPORT jobject JNICALL Java_io_github_toolfactory_narcissus_Narcissus_findMet
     return result;
 }
 
-// Find a method by name and signature. Signature should be of the form "Ljava/lang/String;"
+// Find a field by name and signature. Signature should be of the form "Ljava/lang/String;"
 JNIEXPORT jobject JNICALL Java_io_github_toolfactory_narcissus_Narcissus_findFieldInternal(JNIEnv *env, jclass ignored, jclass cls, jstring field_name, jstring sig, jboolean is_static) {
     if (argIsNull(env, cls) || argIsNull(env, field_name) || argIsNull(env, sig)) { return NULL; }
     const char* field_name_chars = (*env)->GetStringUTFChars(env, field_name, NULL);
@@ -596,9 +826,7 @@ JNIEXPORT jobject JNICALL Java_io_github_toolfactory_narcissus_Narcissus_allocat
     // Finally check modifiers for abstract/interface classes
     jint modifiers = (*env)->CallIntMethod(env, instanceType, Class_getModifiers_methodID);
     if (thrown(env)) { return NULL; }
-    
-    // Check for abstract (0x400) or interface (0x200)
-    if ((modifiers & 0x400) || (modifiers & 0x200)) {
+    if ((modifiers & MODIFIER_ABSTRACT) || (modifiers & MODIFIER_INTERFACE)) {
         throwInstantiationException(env, "Cannot instantiate abstract class or interface");
         return NULL;
     }
@@ -612,17 +840,17 @@ JNIEXPORT void JNICALL Java_io_github_toolfactory_narcissus_Narcissus_sneakyThro
     if (throwable == NULL) {
         throwNullPointerException(env, "throwable is null");
     } else {
-	    (*env)->Throw(env, throwable);
-	}
+        (*env)->Throw(env, throwable);
+    }
 }
 
 // -----------------------------------------------------------------------------------------------------------------
 
 // Non-static field getters:
 
-#define FIELD_GETTER(_prim_type, _Prim_type) \
+#define FIELD_GETTER(_prim_type, _Prim_type, _extra_check) \
 JNIEXPORT j ## _prim_type JNICALL Java_io_github_toolfactory_narcissus_Narcissus_get ## _Prim_type ## Field(JNIEnv *env, jclass ignored, jobject obj, jobject field) { \
-    if (argIsNull(env, obj) || argIsNull(env, field) || !checkFieldStaticModifier(env, field, false) || !checkFieldReceiver(env, obj, field)) { return (j ## _prim_type) 0; } \
+    if (argIsNull(env, obj) || argIsNull(env, field) || !checkFieldStaticModifier(env, field, false) || !checkFieldReceiver(env, obj, field) _extra_check) { return (j ## _prim_type) 0; } \
     jfieldID fieldID = (*env)->FromReflectedField(env, field); \
     if (thrown(env)) { return (j ## _prim_type) 0; } \
     j ## _prim_type result = (*env)->Get ## _Prim_type ## Field(env, obj, fieldID); \
@@ -630,15 +858,15 @@ JNIEXPORT j ## _prim_type JNICALL Java_io_github_toolfactory_narcissus_Narcissus
     return result; \
 }
 
-FIELD_GETTER(int, Int)
-FIELD_GETTER(long, Long)
-FIELD_GETTER(short, Short)
-FIELD_GETTER(char, Char)
-FIELD_GETTER(boolean, Boolean)
-FIELD_GETTER(byte, Byte)
-FIELD_GETTER(float, Float)
-FIELD_GETTER(double, Double)
-FIELD_GETTER(object, Object)
+FIELD_GETTER(int, Int, || !checkFieldPrimitiveType(env, field, int_class) )
+FIELD_GETTER(long, Long, || !checkFieldPrimitiveType(env, field, long_class) )
+FIELD_GETTER(short, Short, || !checkFieldPrimitiveType(env, field, short_class) )
+FIELD_GETTER(char, Char, || !checkFieldPrimitiveType(env, field, char_class) )
+FIELD_GETTER(boolean, Boolean, || !checkFieldPrimitiveType(env, field, boolean_class) )
+FIELD_GETTER(byte, Byte, || !checkFieldPrimitiveType(env, field, byte_class) )
+FIELD_GETTER(float, Float, || !checkFieldPrimitiveType(env, field, float_class) )
+FIELD_GETTER(double, Double, || !checkFieldPrimitiveType(env, field, double_class) )
+FIELD_GETTER(object, Object, || !checkFieldTypeIsReference(env, field) )
 
 // Non-static field setters:
 
@@ -648,44 +876,44 @@ JNIEXPORT void JNICALL Java_io_github_toolfactory_narcissus_Narcissus_set ## _Pr
     jfieldID fieldID = (*env)->FromReflectedField(env, field); \
     if (thrown(env)) { return; } \
     (*env)->Set ## _Prim_type ## Field(env, obj, fieldID, val); \
-    if (thrown(env)) { return; } \
 }
 
-FIELD_SETTER(int, Int, )
-FIELD_SETTER(long, Long, )
-FIELD_SETTER(short, Short, )
-FIELD_SETTER(char, Char, )
-FIELD_SETTER(boolean, Boolean, )
-FIELD_SETTER(byte, Byte, )
-FIELD_SETTER(float, Float, )
-FIELD_SETTER(double, Double, )
-FIELD_SETTER(object, Object, || !checkFieldValType(env, field, val) )
+FIELD_SETTER(int, Int, || !checkFieldPrimitiveType(env, field, int_class) )
+FIELD_SETTER(long, Long, || !checkFieldPrimitiveType(env, field, long_class) )
+FIELD_SETTER(short, Short, || !checkFieldPrimitiveType(env, field, short_class) )
+FIELD_SETTER(char, Char, || !checkFieldPrimitiveType(env, field, char_class) )
+FIELD_SETTER(boolean, Boolean, || !checkFieldPrimitiveType(env, field, boolean_class) )
+FIELD_SETTER(byte, Byte, || !checkFieldPrimitiveType(env, field, byte_class) )
+FIELD_SETTER(float, Float, || !checkFieldPrimitiveType(env, field, float_class) )
+FIELD_SETTER(double, Double, || !checkFieldPrimitiveType(env, field, double_class) )
+FIELD_SETTER(object, Object, || !checkFieldTypeIsReference(env, field) || !checkFieldValType(env, field, val) )
 
 // -----------------------------------------------------------------------------------------------------------------
 
 // Static field getters:
 
-#define STATIC_FIELD_GETTER(_prim_type, _Prim_type) \
+#define STATIC_FIELD_GETTER(_prim_type, _Prim_type, _extra_check) \
 JNIEXPORT j ## _prim_type JNICALL Java_io_github_toolfactory_narcissus_Narcissus_getStatic ## _Prim_type ## Field(JNIEnv *env, jclass ignored, jobject field) { \
-    if (argIsNull(env, field) || !checkFieldStaticModifier(env, field, true)) { return (j ## _prim_type) 0; } \
+    if (argIsNull(env, field) || !checkFieldStaticModifier(env, field, true) _extra_check) { return (j ## _prim_type) 0; } \
     jfieldID fieldID = (*env)->FromReflectedField(env, field); \
     if (thrown(env)) { return (j ## _prim_type) 0; } \
-    jclass cls = (*env)->CallObjectMethod(env, field, Field_getDeclaringClass_methodID); \
+    jclass cls = (jclass) (*env)->CallObjectMethod(env, field, Field_getDeclaringClass_methodID); \
     if (thrown(env)) { return (j ## _prim_type) 0; } \
     j ## _prim_type result = (*env)->GetStatic ## _Prim_type ## Field(env, cls, fieldID); \
+    (*env)->DeleteLocalRef(env, cls); \
     if (thrown(env)) { return (j ## _prim_type) 0; } \
     return result; \
 }
 
-STATIC_FIELD_GETTER(int, Int)
-STATIC_FIELD_GETTER(long, Long)
-STATIC_FIELD_GETTER(short, Short)
-STATIC_FIELD_GETTER(char, Char)
-STATIC_FIELD_GETTER(boolean, Boolean)
-STATIC_FIELD_GETTER(byte, Byte)
-STATIC_FIELD_GETTER(float, Float)
-STATIC_FIELD_GETTER(double, Double)
-STATIC_FIELD_GETTER(object, Object)
+STATIC_FIELD_GETTER(int, Int, || !checkFieldPrimitiveType(env, field, int_class) )
+STATIC_FIELD_GETTER(long, Long, || !checkFieldPrimitiveType(env, field, long_class) )
+STATIC_FIELD_GETTER(short, Short, || !checkFieldPrimitiveType(env, field, short_class) )
+STATIC_FIELD_GETTER(char, Char, || !checkFieldPrimitiveType(env, field, char_class) )
+STATIC_FIELD_GETTER(boolean, Boolean, || !checkFieldPrimitiveType(env, field, boolean_class) )
+STATIC_FIELD_GETTER(byte, Byte, || !checkFieldPrimitiveType(env, field, byte_class) )
+STATIC_FIELD_GETTER(float, Float, || !checkFieldPrimitiveType(env, field, float_class) )
+STATIC_FIELD_GETTER(double, Double, || !checkFieldPrimitiveType(env, field, double_class) )
+STATIC_FIELD_GETTER(object, Object, || !checkFieldTypeIsReference(env, field) )
 
 // Static field setters:
 
@@ -694,21 +922,21 @@ JNIEXPORT void JNICALL Java_io_github_toolfactory_narcissus_Narcissus_setStatic 
     if (argIsNull(env, field) || !checkFieldStaticModifier(env, field, true) _extra_check) { return; } \
     jfieldID fieldID = (*env)->FromReflectedField(env, field); \
     if (thrown(env)) { return; } \
-    jclass cls = (*env)->CallObjectMethod(env, field, Field_getDeclaringClass_methodID); \
+    jclass cls = (jclass) (*env)->CallObjectMethod(env, field, Field_getDeclaringClass_methodID); \
     if (thrown(env)) { return; } \
     (*env)->SetStatic ## _Prim_type ## Field(env, cls, fieldID, val); \
-    if (thrown(env)) { return; } \
+    (*env)->DeleteLocalRef(env, cls); \
 }
 
-STATIC_FIELD_SETTER(int, Int, )
-STATIC_FIELD_SETTER(long, Long, )
-STATIC_FIELD_SETTER(short, Short, )
-STATIC_FIELD_SETTER(char, Char, )
-STATIC_FIELD_SETTER(boolean, Boolean, )
-STATIC_FIELD_SETTER(byte, Byte, )
-STATIC_FIELD_SETTER(float, Float, )
-STATIC_FIELD_SETTER(double, Double, )
-STATIC_FIELD_SETTER(object, Object, || !checkFieldValType(env, field, val) )
+STATIC_FIELD_SETTER(int, Int, || !checkFieldPrimitiveType(env, field, int_class) )
+STATIC_FIELD_SETTER(long, Long, || !checkFieldPrimitiveType(env, field, long_class) )
+STATIC_FIELD_SETTER(short, Short, || !checkFieldPrimitiveType(env, field, short_class) )
+STATIC_FIELD_SETTER(char, Char, || !checkFieldPrimitiveType(env, field, char_class) )
+STATIC_FIELD_SETTER(boolean, Boolean, || !checkFieldPrimitiveType(env, field, boolean_class) )
+STATIC_FIELD_SETTER(byte, Byte, || !checkFieldPrimitiveType(env, field, byte_class) )
+STATIC_FIELD_SETTER(float, Float, || !checkFieldPrimitiveType(env, field, float_class) )
+STATIC_FIELD_SETTER(double, Double, || !checkFieldPrimitiveType(env, field, double_class) )
+STATIC_FIELD_SETTER(object, Object, || !checkFieldTypeIsReference(env, field) || !checkFieldValType(env, field, val) )
 
 // -----------------------------------------------------------------------------------------------------------------
 
@@ -716,19 +944,20 @@ STATIC_FIELD_SETTER(object, Object, || !checkFieldValType(env, field, val) )
 
 #define INVOKE_METHOD(_jni_ret_type, _prim_type, _Prim_type, _assign, _assign_return, _err_return, _extra_check) \
 JNIEXPORT _jni_ret_type JNICALL Java_io_github_toolfactory_narcissus_Narcissus_invoke ## _Prim_type ## Method(JNIEnv *env, jclass ignored, jobject obj, jobject method, jobjectArray args) { \
-    if (argIsNull(env, obj) || argIsNull(env, method) || argIsNull(env, args) || !checkMethodStaticModifier(env, method, false) || !checkMethodReceiver(env, obj, method) _extra_check) { return _err_return; } \
+    if (argIsNull(env, obj) || argIsNull(env, method) || !checkMethodStaticModifier(env, method, false) || !checkMethodReceiver(env, obj, method) _extra_check) { return _err_return; } \
     jmethodID methodID = (*env)->FromReflectedMethod(env, method); \
     if (thrown(env)) { return _err_return; } \
-    jsize num_args = (*env)->GetArrayLength(env, args); \
-    if (thrown(env)) { return _err_return; } \
-    jvalue arg_jvalues[num_args == 0 ? 1 : num_args]; \
-    if (unbox(env, method, args, num_args, arg_jvalues)) { \
-        _assign (*env)->Call ## _Prim_type ## MethodA(env, obj, methodID, arg_jvalues); \
+    /* A null args array is treated as an empty args array, as in Method.invoke() */ \
+    jsize num_args = 0; \
+    if (args != NULL) { \
+        num_args = (*env)->GetArrayLength(env, args); \
         if (thrown(env)) { return _err_return; } \
-        return _assign_return; \
-    } else {\
-        return _err_return; \
     } \
+    jvalue arg_jvalues[MAX_METHOD_PARAMS]; \
+    if (!unbox(env, method, args, num_args, arg_jvalues)) { return _err_return; } \
+    _assign (*env)->Call ## _Prim_type ## MethodA(env, obj, methodID, arg_jvalues); \
+    if (thrown(env)) { return _err_return; } \
+    return _assign_return; \
 }
 
 INVOKE_METHOD(void, void, Void, , , , || !checkPrimitiveMethodReturnType(env, method, void_class) )
@@ -748,21 +977,22 @@ INVOKE_METHOD(jobject, object, Object, jobject return_val = , return_val, NULL, 
 
 #define INVOKE_STATIC_METHOD(_jni_ret_type, _prim_type, _Prim_type, _assign, _assign_return, _err_return, _extra_check) \
 JNIEXPORT _jni_ret_type JNICALL Java_io_github_toolfactory_narcissus_Narcissus_invokeStatic ## _Prim_type ## Method(JNIEnv *env, jclass ignored, jobject method, jobjectArray args) { \
-    if (argIsNull(env, method) || argIsNull(env, args) || !checkMethodStaticModifier(env, method, true) _extra_check) { return _err_return; } \
-    jclass cls = (*env)->CallObjectMethod(env, method, Method_getDeclaringClass_methodID); \
+    if (argIsNull(env, method) || !checkMethodStaticModifier(env, method, true) _extra_check) { return _err_return; } \
+    jclass cls = (jclass) (*env)->CallObjectMethod(env, method, Method_getDeclaringClass_methodID); \
     if (thrown(env)) { return _err_return; } \
     jmethodID methodID = (*env)->FromReflectedMethod(env, method); \
     if (thrown(env)) { return _err_return; } \
-    jsize num_args = (*env)->GetArrayLength(env, args); \
-    if (thrown(env)) { return _err_return; } \
-    jvalue arg_jvalues[num_args == 0 ? 1 : num_args]; \
-    if (unbox(env, method, args, num_args, arg_jvalues)) { \
-        _assign (*env)->CallStatic ## _Prim_type ## MethodA(env, cls, methodID, arg_jvalues); \
+    /* A null args array is treated as an empty args array, as in Method.invoke() */ \
+    jsize num_args = 0; \
+    if (args != NULL) { \
+        num_args = (*env)->GetArrayLength(env, args); \
         if (thrown(env)) { return _err_return; } \
-        return _assign_return; \
-    } else { \
-        return _err_return; \
     } \
+    jvalue arg_jvalues[MAX_METHOD_PARAMS]; \
+    if (!unbox(env, method, args, num_args, arg_jvalues)) { return _err_return; } \
+    _assign (*env)->CallStatic ## _Prim_type ## MethodA(env, cls, methodID, arg_jvalues); \
+    if (thrown(env)) { return _err_return; } \
+    return _assign_return; \
 }
 
 INVOKE_STATIC_METHOD(void, void, Void, , , , || !checkPrimitiveMethodReturnType(env, method, void_class) )
@@ -775,4 +1005,3 @@ INVOKE_STATIC_METHOD(jbyte, byte, Byte, jbyte return_val = , return_val, (jbyte)
 INVOKE_STATIC_METHOD(jfloat, float, Float, jfloat return_val = , return_val, (jfloat) 0, || !checkPrimitiveMethodReturnType(env, method, float_class) )
 INVOKE_STATIC_METHOD(jdouble, double, Double, jdouble return_val = , return_val, (jdouble) 0, || !checkPrimitiveMethodReturnType(env, method, double_class) )
 INVOKE_STATIC_METHOD(jobject, object, Object, jobject return_val = , return_val, NULL, || !checkMethodReturnTypeNotVoidOrPrimitive(env, method) )
-

--- a/src/main/java/io/github/toolfactory/narcissus/LibraryLoader.java
+++ b/src/main/java/io/github/toolfactory/narcissus/LibraryLoader.java
@@ -40,14 +40,8 @@ class LibraryLoader {
     /** The operating system type. */
     public static final OperatingSystem OS;
 
-    /** The machine word size. */
-    public static int archBits;
-
-    /** The architecture name (empty except on Mac) */
-    public static String archName = "";
-
-    /** The architecture type (x64, arm64, x86) */
-    public static String archType;
+    /** The architecture type (x64, x86, arm64 or arm32). */
+    public static final String archType;
 
     /** The operating system type. */
     enum OperatingSystem {
@@ -91,38 +85,41 @@ class LibraryLoader {
         } else if (osName.contains("sunos") || osName.contains("solaris")) {
             OS = OperatingSystem.Solaris;
         } else if (osName.contains("bsd")) {
-            OS = OperatingSystem.Unix;
+            OS = OperatingSystem.BSD;
         } else if (osName.contains("nix") || osName.contains("aix")) {
             OS = OperatingSystem.Unix;
         } else {
             OS = OperatingSystem.Unknown;
         }
 
-        if (OS == OperatingSystem.MacOSX && "aarch64".equals(System.getProperty("os.arch"))) {
-            archName = "arm";
+        // Determine architecture type. Note that ARM has to be distinguished from x86 before the word size is
+        // consulted, otherwise a 32-bit ARM machine is labeled "x86", and the loader then tries to load an x86
+        // library on an ARM machine.
+        String osArch = null;
+        try {
+            osArch = System.getProperty("os.arch", "").toLowerCase(Locale.ENGLISH);
+        } catch (final SecurityException e) {
+            // Ignore
         }
-
-        // Determine architecture type
-        final String osArch = System.getProperty("os.arch");
-        if (osArch != null && "aarch64".equals(osArch)) {
+        String dataModel = null;
+        try {
+            dataModel = System.getProperty("sun.arch.data.model");
+        } catch (final SecurityException e) {
+            // Ignore
+        }
+        final boolean is32Bit = dataModel != null && dataModel.contains("32");
+        if (osArch == null) {
+            archType = is32Bit ? "x86" : "x64";
+        } else if (osArch.equals("aarch64") || osArch.equals("arm64")) {
             archType = "arm64";
+        } else if (osArch.startsWith("arm")) {
+            // 32-bit ARM (armv7l, armhf, etc.) -- no library is built for this architecture, but naming it
+            // correctly produces a clearer error than trying to load the x86 library
+            archType = "arm32";
+        } else if (is32Bit || (osArch.contains("86") && !osArch.contains("64")) || osArch.contains("32")) {
+            archType = "x86";
         } else {
-            archBits = 64;
-            final String dataModel = System.getProperty("sun.arch.data.model");
-            if (dataModel != null && dataModel.contains("32")) {
-                archBits = 32;
-                archType = "x86";
-            } else if (osArch != null && ((osArch.contains("86") && !osArch.contains("64")) || osArch.contains("32"))) {
-                archBits = 32;
-                archType = "x86";
-            } else {
-                archType = "x64";
-            }
-        }
-
-        // Set archBits for ARM64
-        if ("arm64".equals(archType)) {
-            archBits = 64;
+            archType = "x64";
         }
     }
 
@@ -135,7 +132,7 @@ class LibraryLoader {
     static void loadLibraryFromJar(final String libraryResourcePath) {
         File tempFile = null;
         boolean tempFileIsPosix = false;
-        Exception exception = null;
+        Throwable exception = null;
         try (InputStream inputSream = Narcissus.class.getResourceAsStream(
                 libraryResourcePath.startsWith("/") ? libraryResourcePath : "/" + libraryResourcePath)) {
             if (inputSream == null) {
@@ -157,6 +154,12 @@ class LibraryLoader {
             } catch (final Exception e) {
                 // Ignore
             }
+            if (!tempFileIsPosix) {
+                // A non-POSIX filesystem (i.e. Windows) will not let the temp file be deleted while it is
+                // mapped into this process, so delete any temp files left behind by previous JVMs instead.
+                // A file that is still mapped into a running JVM simply fails to delete.
+                deleteStaleTempFiles(tempFile.getParentFile(), baseName + "_", suffix, tempFile);
+            }
 
             final byte[] buffer = new byte[8192];
             try (final OutputStream os = new FileOutputStream(tempFile)) {
@@ -168,14 +171,57 @@ class LibraryLoader {
             // Load the library
             System.load(tempFile.getAbsolutePath());
 
-        } catch (final Exception e) {
-            exception = e;
+            // Catch Throwable rather than Exception, since System.load() throws UnsatisfiedLinkError, which
+            // would otherwise skip the deletion of the temp file below
+        } catch (final Throwable t) {
+            exception = t;
         }
-        if (tempFile != null && tempFileIsPosix) {
+        if (tempFile != null && (tempFileIsPosix || exception != null)) {
+            // On POSIX filesystems the library stays mapped into the process after the file is unlinked, so
+            // the temp file can be deleted as soon as it has been loaded. On other filesystems (i.e. Windows)
+            // a mapped file cannot be deleted, so the temp file can only be deleted if the load failed, which
+            // means nothing was mapped. (Deletion is best-effort in that case -- if it fails, the file is
+            // deleted on exit, or swept as a stale temp file by the next JVM.)
             tempFile.delete();
         }
         if (exception != null) {
-            throw new RuntimeException("Could not load library " + libraryResourcePath + " : " + exception);
+            throw new RuntimeException("Could not load library " + libraryResourcePath + " : " + exception,
+                    exception);
+        }
+    }
+
+    /**
+     * Delete temp files extracted by previous JVM invocations, which could not be deleted at the time because the
+     * library was still mapped into the process.
+     *
+     * @param tempDir
+     *            the temporary directory
+     * @param prefix
+     *            the temp filename prefix
+     * @param suffix
+     *            the temp filename suffix
+     * @param currentTempFile
+     *            the temp file extracted by this JVM, which must not be deleted
+     */
+    private static void deleteStaleTempFiles(final File tempDir, final String prefix, final String suffix,
+            final File currentTempFile) {
+        try {
+            if (tempDir == null) {
+                return;
+            }
+            final File[] files = tempDir.listFiles();
+            if (files == null) {
+                return;
+            }
+            for (final File file : files) {
+                final String name = file.getName();
+                if (name.startsWith(prefix) && name.endsWith(suffix) && !file.equals(currentTempFile)) {
+                    // Fails harmlessly if the file is still mapped into another running JVM
+                    file.delete();
+                }
+            }
+        } catch (final Exception e) {
+            // Ignore -- sweeping stale temp files is best-effort
         }
     }
 }

--- a/src/main/java/io/github/toolfactory/narcissus/Narcissus.java
+++ b/src/main/java/io/github/toolfactory/narcissus/Narcissus.java
@@ -180,9 +180,50 @@ public class Narcissus {
     private static native Field findFieldInternal(Class<?> cls, String fieldName, String sig, boolean isStatic);
 
     /**
-     * Finds a class by name (e.g. {@code "com.xyz.MyClass"}) using the current classloader or the system
-     * classloader, ignoring visibility and bypassing security checks. Finds array classes if the class name is of
-     * the form {@code "com.xyz.MyClass[][]"}.
+     * The names, classes and type descriptors of the primitive types, held in a nested class so that they are
+     * initialized on first use, rather than in the initialization order of {@link Narcissus} itself (the static
+     * initializer block of {@link Narcissus} calls {@link #findClass(String)}, which reads these arrays).
+     */
+    private static class Primitives {
+        /** The primitive type names, in the same order as {@link #CLASSES} and {@link #DESCRIPTORS}. */
+        static final String[] NAMES = { "int", "long", "short", "char", "boolean", "byte", "float", "double",
+                "void" };
+
+        /** The primitive classes, in the same order as {@link #NAMES}. */
+        static final Class<?>[] CLASSES = { int.class, long.class, short.class, char.class, boolean.class,
+                byte.class, float.class, double.class, void.class };
+
+        /** The primitive type descriptors, in the same order as {@link #NAMES}. */
+        static final String[] DESCRIPTORS = { "I", "J", "S", "C", "Z", "B", "F", "D", "V" };
+    }
+
+    /**
+     * Get the index of a primitive type name in {@link Primitives#NAMES}.
+     *
+     * @param typeName
+     *            the type name
+     * @return the index of the type name, or -1 if the name is not the name of a primitive type
+     */
+    private static int primitiveTypeIdx(final String typeName) {
+        for (int i = 0; i < Primitives.NAMES.length; i++) {
+            if (Primitives.NAMES[i].equals(typeName)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Finds a class by name (e.g. {@code "com.xyz.MyClass"}), ignoring visibility and bypassing security checks.
+     * Finds array classes if the class name is of the form {@code "com.xyz.MyClass[][]"}, and returns the primitive
+     * class if the class name is the name of a primitive type (e.g. {@code "int"} returns {@code int.class}).
+     *
+     * <p>
+     * The class is resolved by the classloader that loaded Narcissus, which is not necessarily the classloader of
+     * the caller. A class that is not visible to that classloader cannot be found by this method, even if it is
+     * visible to the caller -- use {@link Class#forName(String, boolean, ClassLoader)} for those. Note also that
+     * this method throws {@link NoClassDefFoundError} rather than {@link ClassNotFoundException} if the class
+     * cannot be found, since that is what the underlying JNI {@code FindClass} function throws.
      *
      * @param className
      *            the class name
@@ -193,13 +234,27 @@ public class Narcissus {
             throw new IllegalArgumentException("Class name cannot be null");
         }
         String classNameInternal = className.replace('.', '/');
-        String arrayDims = "";
+        int arrayDims = 0;
         while (classNameInternal.endsWith("[]")) {
-            arrayDims += '[';
+            arrayDims++;
             classNameInternal = classNameInternal.substring(0, classNameInternal.length() - 2);
         }
-        return findClassInternal(
-                arrayDims.isEmpty() ? classNameInternal : arrayDims + 'L' + classNameInternal + ';');
+        final int primitiveIdx = primitiveTypeIdx(classNameInternal);
+        if (arrayDims == 0) {
+            // JNI FindClass cannot look up a primitive type, since primitive types have no binary name
+            return primitiveIdx >= 0 ? Primitives.CLASSES[primitiveIdx] : findClassInternal(classNameInternal);
+        }
+        // Build the array class descriptor, e.g. "[[I" for "int[][]", or "[Ljava/lang/String;" for "String[]"
+        final StringBuilder descriptor = new StringBuilder();
+        for (int i = 0; i < arrayDims; i++) {
+            descriptor.append('[');
+        }
+        if (primitiveIdx >= 0) {
+            descriptor.append(Primitives.DESCRIPTORS[primitiveIdx]);
+        } else {
+            descriptor.append('L').append(classNameInternal).append(';');
+        }
+        return findClassInternal(descriptor.toString());
     }
 
     // -------------------------------------------------------------------------------------------------------------
@@ -545,10 +600,10 @@ public class Narcissus {
      */
     public static Object getField(final Object object, final Field field) {
         if (object == null) {
-            throw new IllegalArgumentException("object cannot be null");
+            throw new NullPointerException("object cannot be null");
         }
         if (field == null) {
-            throw new IllegalArgumentException("field cannot be null");
+            throw new NullPointerException("field cannot be null");
         }
         if (Modifier.isStatic(field.getModifiers())) {
             throw new IllegalArgumentException("field is static, call getStaticField() instead");
@@ -684,8 +739,167 @@ public class Narcissus {
     public static native void setObjectField(Object object, Field field, Object val);
 
     /**
-     * Set the value of an object field, ignoring visibility and bypassing security checks, unboxing the passed
-     * value if necessary.
+     * Build an {@link IllegalArgumentException} describing a value that cannot be assigned to a field.
+     *
+     * @param field
+     *            the field
+     * @param val
+     *            the value that could not be assigned to the field
+     * @return the exception to throw
+     */
+    private static IllegalArgumentException badValue(final Field field, final Object val) {
+        return new IllegalArgumentException("Cannot assign a value of type "
+                + (val == null ? "null" : val.getClass().getName()) + " to field "
+                + field.getDeclaringClass().getName() + "." + field.getName() + " of type "
+                + field.getType().getName());
+    }
+
+    /**
+     * Unbox a value for assignment to a boolean-typed field.
+     *
+     * @param field
+     *            the field the value is being assigned to
+     * @param val
+     *            the value to unbox
+     * @return the unboxed value
+     */
+    private static boolean booleanValue(final Field field, final Object val) {
+        if (val instanceof Boolean) {
+            return ((Boolean) val).booleanValue();
+        }
+        throw badValue(field, val);
+    }
+
+    /**
+     * Unbox a value for assignment to a byte-typed field.
+     *
+     * @param field
+     *            the field the value is being assigned to
+     * @param val
+     *            the value to unbox
+     * @return the unboxed value
+     */
+    private static byte byteValue(final Field field, final Object val) {
+        if (val instanceof Byte) {
+            return ((Byte) val).byteValue();
+        }
+        throw badValue(field, val);
+    }
+
+    /**
+     * Unbox a value for assignment to a char-typed field.
+     *
+     * @param field
+     *            the field the value is being assigned to
+     * @param val
+     *            the value to unbox
+     * @return the unboxed value
+     */
+    private static char charValue(final Field field, final Object val) {
+        if (val instanceof Character) {
+            return ((Character) val).charValue();
+        }
+        throw badValue(field, val);
+    }
+
+    /**
+     * Unbox a value for assignment to a short-typed field, applying widening primitive conversion (JLS 5.1.2).
+     *
+     * @param field
+     *            the field the value is being assigned to
+     * @param val
+     *            the value to unbox
+     * @return the unboxed value
+     */
+    private static short shortValue(final Field field, final Object val) {
+        if (val instanceof Short || val instanceof Byte) {
+            return ((Number) val).shortValue();
+        }
+        throw badValue(field, val);
+    }
+
+    /**
+     * Unbox a value for assignment to an int-typed field, applying widening primitive conversion (JLS 5.1.2).
+     *
+     * @param field
+     *            the field the value is being assigned to
+     * @param val
+     *            the value to unbox
+     * @return the unboxed value
+     */
+    private static int intValue(final Field field, final Object val) {
+        if (val instanceof Integer || val instanceof Short || val instanceof Byte) {
+            return ((Number) val).intValue();
+        }
+        if (val instanceof Character) {
+            return ((Character) val).charValue();
+        }
+        throw badValue(field, val);
+    }
+
+    /**
+     * Unbox a value for assignment to a long-typed field, applying widening primitive conversion (JLS 5.1.2).
+     *
+     * @param field
+     *            the field the value is being assigned to
+     * @param val
+     *            the value to unbox
+     * @return the unboxed value
+     */
+    private static long longValue(final Field field, final Object val) {
+        if (val instanceof Long || val instanceof Integer || val instanceof Short || val instanceof Byte) {
+            return ((Number) val).longValue();
+        }
+        if (val instanceof Character) {
+            return ((Character) val).charValue();
+        }
+        throw badValue(field, val);
+    }
+
+    /**
+     * Unbox a value for assignment to a float-typed field, applying widening primitive conversion (JLS 5.1.2).
+     *
+     * @param field
+     *            the field the value is being assigned to
+     * @param val
+     *            the value to unbox
+     * @return the unboxed value
+     */
+    private static float floatValue(final Field field, final Object val) {
+        if (val instanceof Float || val instanceof Long || val instanceof Integer || val instanceof Short
+                || val instanceof Byte) {
+            return ((Number) val).floatValue();
+        }
+        if (val instanceof Character) {
+            return ((Character) val).charValue();
+        }
+        throw badValue(field, val);
+    }
+
+    /**
+     * Unbox a value for assignment to a double-typed field, applying widening primitive conversion (JLS 5.1.2).
+     *
+     * @param field
+     *            the field the value is being assigned to
+     * @param val
+     *            the value to unbox
+     * @return the unboxed value
+     */
+    private static double doubleValue(final Field field, final Object val) {
+        if (val instanceof Double || val instanceof Float || val instanceof Long || val instanceof Integer
+                || val instanceof Short || val instanceof Byte) {
+            return ((Number) val).doubleValue();
+        }
+        if (val instanceof Character) {
+            return ((Character) val).charValue();
+        }
+        throw badValue(field, val);
+    }
+
+    /**
+     * Set the value of a field, ignoring visibility and bypassing security checks, unboxing the passed value if
+     * the field is of primitive type. Widening primitive conversion (JLS 5.1.2) is applied to the unboxed value if
+     * necessary, so for example an {@link Integer} may be assigned to a {@code long} field.
      *
      * @param object
      *            the object instance in which to set the field value
@@ -693,6 +907,8 @@ public class Narcissus {
      *            the non-static field
      * @param val
      *            the value to set
+     * @throws IllegalArgumentException
+     *             if the field is of primitive type and the value cannot be converted to that type
      */
     public static void setField(final Object object, final Field field, final Object val) {
         if (object == null) {
@@ -706,21 +922,21 @@ public class Narcissus {
         }
         final Class<?> fieldType = field.getType();
         if (fieldType == int.class) {
-            setIntField(object, field, ((Integer) val).intValue());
+            setIntField(object, field, intValue(field, val));
         } else if (fieldType == long.class) {
-            setLongField(object, field, ((Long) val).longValue());
+            setLongField(object, field, longValue(field, val));
         } else if (fieldType == short.class) {
-            setShortField(object, field, ((Short) val).shortValue());
+            setShortField(object, field, shortValue(field, val));
         } else if (fieldType == char.class) {
-            setCharField(object, field, ((Character) val).charValue());
+            setCharField(object, field, charValue(field, val));
         } else if (fieldType == boolean.class) {
-            setBooleanField(object, field, ((Boolean) val).booleanValue());
+            setBooleanField(object, field, booleanValue(field, val));
         } else if (fieldType == byte.class) {
-            setByteField(object, field, ((Byte) val).byteValue());
+            setByteField(object, field, byteValue(field, val));
         } else if (fieldType == float.class) {
-            setFloatField(object, field, ((Float) val).floatValue());
+            setFloatField(object, field, floatValue(field, val));
         } else if (fieldType == double.class) {
-            setDoubleField(object, field, ((Double) val).doubleValue());
+            setDoubleField(object, field, doubleValue(field, val));
         } else {
             setObjectField(object, field, val);
         }
@@ -940,12 +1156,15 @@ public class Narcissus {
 
     /**
      * Set the value of a static field, ignoring visibility and bypassing security checks, unboxing the passed value
-     * if necessary.
+     * if the field is of primitive type. Widening primitive conversion (JLS 5.1.2) is applied to the unboxed value
+     * if necessary, so for example an {@link Integer} may be assigned to a {@code long} field.
      *
      * @param field
      *            the static field
      * @param val
      *            the value to set
+     * @throws IllegalArgumentException
+     *             if the field is of primitive type and the value cannot be converted to that type
      */
     public static void setStaticField(final Field field, final Object val) {
         if (field == null) {
@@ -956,21 +1175,21 @@ public class Narcissus {
         }
         final Class<?> fieldType = field.getType();
         if (fieldType == int.class) {
-            setStaticIntField(field, ((Integer) val).intValue());
+            setStaticIntField(field, intValue(field, val));
         } else if (fieldType == long.class) {
-            setStaticLongField(field, ((Long) val).longValue());
+            setStaticLongField(field, longValue(field, val));
         } else if (fieldType == short.class) {
-            setStaticShortField(field, ((Short) val).shortValue());
+            setStaticShortField(field, shortValue(field, val));
         } else if (fieldType == char.class) {
-            setStaticCharField(field, ((Character) val).charValue());
+            setStaticCharField(field, charValue(field, val));
         } else if (fieldType == boolean.class) {
-            setStaticBooleanField(field, ((Boolean) val).booleanValue());
+            setStaticBooleanField(field, booleanValue(field, val));
         } else if (fieldType == byte.class) {
-            setStaticByteField(field, ((Byte) val).byteValue());
+            setStaticByteField(field, byteValue(field, val));
         } else if (fieldType == float.class) {
-            setStaticFloatField(field, ((Float) val).floatValue());
+            setStaticFloatField(field, floatValue(field, val));
         } else if (fieldType == double.class) {
-            setStaticDoubleField(field, ((Double) val).doubleValue());
+            setStaticDoubleField(field, doubleValue(field, val));
         } else {
             setStaticObjectField(field, val);
         }

--- a/src/main/java/io/github/toolfactory/narcissus/ReflectionCache.java
+++ b/src/main/java/io/github/toolfactory/narcissus/ReflectionCache.java
@@ -59,7 +59,12 @@ public class ReflectionCache {
             methodsForName.add(method);
         }
         for (final Field field : Narcissus.enumerateFields(cls)) {
-            fieldNameToField.put(field.getName(), field);
+            // enumerateFields() lists the fields of the class before the fields of its superclasses, so if a
+            // field shadows a field of the same name in a superclass, the shadowing field is seen first, and
+            // must be the one that is cached -- this matches the behavior of Narcissus.findField()
+            if (!fieldNameToField.containsKey(field.getName())) {
+                fieldNameToField.put(field.getName(), field);
+            }
         }
     }
 

--- a/src/test/java/io/github/toolfactory/narcissus/LibraryLoaderTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/LibraryLoaderTest.java
@@ -1,0 +1,181 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/** Tests {@link LibraryLoader}: operating system and architecture detection, and library extraction. */
+@ExtendWith(TestMethodNameLogger.class)
+public class LibraryLoaderTest {
+
+    /** A resource that is on the classpath but is not a loadable native library. */
+    private static final String NOT_A_LIBRARY = "/io/github/toolfactory/narcissus/Narcissus.class";
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    @Test
+    public void testOperatingSystemDetection() {
+        final String osName = System.getProperty("os.name", "unknown").toLowerCase(Locale.ENGLISH);
+        if (osName.contains("mac") || osName.contains("darwin")) {
+            assertThat(LibraryLoader.OS).isEqualTo(LibraryLoader.OperatingSystem.MacOSX);
+        } else if (osName.contains("win")) {
+            assertThat(LibraryLoader.OS).isEqualTo(LibraryLoader.OperatingSystem.Windows);
+        } else if (osName.contains("nux")) {
+            assertThat(LibraryLoader.OS).isEqualTo(LibraryLoader.OperatingSystem.Linux);
+        }
+        // A library is only built for the three operating systems above, so if the library loaded, the
+        // operating system must be one of them
+        assertThat(LibraryLoader.OS).isIn(LibraryLoader.OperatingSystem.MacOSX,
+                LibraryLoader.OperatingSystem.Windows, LibraryLoader.OperatingSystem.Linux);
+    }
+
+    @Test
+    public void testArchitectureDetection() {
+        assertThat(LibraryLoader.archType).isIn("x64", "x86", "arm64", "arm32");
+        final String osArch = System.getProperty("os.arch", "").toLowerCase(Locale.ENGLISH);
+        if (osArch.equals("aarch64") || osArch.equals("arm64")) {
+            assertThat(LibraryLoader.archType).isEqualTo("arm64");
+        } else if (osArch.startsWith("arm")) {
+            assertThat(LibraryLoader.archType).isEqualTo("arm32");
+        } else if (osArch.equals("amd64") || osArch.equals("x86_64")) {
+            assertThat(LibraryLoader.archType).isEqualTo("x64");
+        }
+    }
+
+    @Test
+    public void testTheLibraryForThisPlatformIsOnTheClasspath() throws Exception {
+        final String extension = LibraryLoader.OS == LibraryLoader.OperatingSystem.MacOSX ? ".dylib"
+                : LibraryLoader.OS == LibraryLoader.OperatingSystem.Windows ? ".dll" : ".so";
+        final String osName = LibraryLoader.OS == LibraryLoader.OperatingSystem.MacOSX ? "macos"
+                : LibraryLoader.OS == LibraryLoader.OperatingSystem.Windows ? "win" : "linux";
+        final String resourcePath = "/lib/libnarcissus-" + osName + "-" + LibraryLoader.archType + extension;
+        final InputStream inputStream = Narcissus.class.getResourceAsStream(resourcePath);
+        assertThat(inputStream).as("library resource " + resourcePath).isNotNull();
+        inputStream.close();
+    }
+
+    @Test
+    public void testLoadLibraryFromJarWithNonexistentResource() {
+        try {
+            LibraryLoader.loadLibraryFromJar("/lib/no-such-library.so");
+            fail("loadLibraryFromJar() should have thrown RuntimeException");
+        } catch (final RuntimeException e) {
+            assertThat(e.getMessage()).contains("no-such-library.so");
+            assertThat(e.getCause()).isInstanceOf(FileNotFoundException.class);
+        }
+    }
+
+    @Test
+    public void testLoadLibraryFromJarWithResourceThatIsNotALibrary() {
+        // System.load() throws UnsatisfiedLinkError, which is an Error rather than an Exception -- it must
+        // still be wrapped in a RuntimeException, and the extracted temp file must still be deleted
+        try {
+            LibraryLoader.loadLibraryFromJar(NOT_A_LIBRARY);
+            fail("loadLibraryFromJar() should have thrown RuntimeException");
+        } catch (final RuntimeException e) {
+            assertThat(e.getMessage()).contains("Narcissus.class");
+            assertThat(e.getCause()).isInstanceOf(UnsatisfiedLinkError.class);
+        }
+        // Deletion is only guaranteed on a POSIX filesystem -- on Windows the delete can lose a race with a
+        // virus scanner that still holds the file open, and the file is then only deleted on exit
+        if (tempDirIsPosix()) {
+            assertThat(listTempFiles("Narcissus_", ".class")).as("temp files left behind after a failed load")
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    public void testLoadLibraryFromJarAcceptsAPathWithoutALeadingSlash() {
+        // The leading slash is optional
+        try {
+            LibraryLoader.loadLibraryFromJar(NOT_A_LIBRARY.substring(1));
+            fail("loadLibraryFromJar() should have thrown RuntimeException");
+        } catch (final RuntimeException e) {
+            assertThat(e.getCause()).isInstanceOf(UnsatisfiedLinkError.class);
+        }
+    }
+
+    @Test
+    public void testDeleteStaleTempFiles() throws Exception {
+        final Method deleteStaleTempFiles = Narcissus.findMethod(LibraryLoader.class, "deleteStaleTempFiles",
+                File.class, String.class, String.class, File.class);
+
+        final File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        final File stale = File.createTempFile("narcissus_stale_test_", ".tmp");
+        final File current = File.createTempFile("narcissus_stale_test_", ".tmp");
+        final File otherSuffix = File.createTempFile("narcissus_stale_test_", ".other");
+        try {
+            Narcissus.invokeStaticVoidMethod(deleteStaleTempFiles, tempDir, "narcissus_stale_test_", ".tmp",
+                    current);
+            // The stale file is deleted, but the current file and files with a different suffix are kept
+            assertThat(stale).doesNotExist();
+            assertThat(current).exists();
+            assertThat(otherSuffix).exists();
+
+            // A null temp directory is ignored rather than throwing
+            Narcissus.invokeStaticVoidMethod(deleteStaleTempFiles, null, "narcissus_stale_test_", ".tmp", current);
+
+            // A temp directory that is not a directory is ignored rather than throwing
+            Narcissus.invokeStaticVoidMethod(deleteStaleTempFiles, current, "narcissus_stale_test_", ".tmp",
+                    current);
+        } finally {
+            stale.delete();
+            current.delete();
+            otherSuffix.delete();
+        }
+    }
+
+    /**
+     * Test whether the temp directory is on a POSIX filesystem.
+     *
+     * @return true if the temp directory is on a POSIX filesystem
+     */
+    private static boolean tempDirIsPosix() {
+        try {
+            return new File(System.getProperty("java.io.tmpdir")).toPath().getFileSystem()
+                    .supportedFileAttributeViews().contains("posix");
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * List the files in the temp directory whose name has the given prefix and suffix.
+     *
+     * @param prefix
+     *            the filename prefix
+     * @param suffix
+     *            the filename suffix
+     * @return the matching filenames
+     */
+    private static String[] listTempFiles(final String prefix, final String suffix) {
+        final File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        final String[] names = tempDir.list();
+        if (names == null) {
+            return new String[0];
+        }
+        int numMatching = 0;
+        for (int i = 0; i < names.length; i++) {
+            if (names[i].startsWith(prefix) && names[i].endsWith(suffix)) {
+                names[numMatching++] = names[i];
+            }
+        }
+        final String[] matching = new String[numMatching];
+        System.arraycopy(names, 0, matching, 0, numMatching);
+        return matching;
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusExceptionAndAccessTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusExceptionAndAccessTest.java
@@ -1,0 +1,216 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests that an exception thrown by an invoked method propagates to the caller unchanged, rather than being
+ * wrapped in an {@link java.lang.reflect.InvocationTargetException}, and tests access to members that reflection
+ * would normally refuse: private members, and final fields.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusExceptionAndAccessTest {
+
+    /** An exception type declared by this test, so it cannot be thrown by anything else. */
+    @SuppressWarnings("serial")
+    public static class TestException extends Exception {
+        /**
+         * Constructor.
+         *
+         * @param message
+         *            the message
+         */
+        public TestException(final String message) {
+            super(message);
+        }
+    }
+
+    /** An error type declared by this test, so it cannot be thrown by anything else. */
+    @SuppressWarnings("serial")
+    public static class TestError extends Error {
+        /**
+         * Constructor.
+         *
+         * @param message
+         *            the message
+         */
+        public TestError(final String message) {
+            super(message);
+        }
+    }
+
+    /** A class whose methods throw, and whose members are private or final. */
+    public static class Thrower {
+        private final int privateFinalIntField = 1;
+        private String privateField = "private";
+        final String finalField = "final";
+        static final String STATIC_FINAL_FIELD;
+        private static String privateStaticField = "privateStatic";
+
+        static {
+            // Assigned in a static initializer, so it is not a compile-time constant, and reads of it are
+            // therefore not inlined by the compiler
+            STATIC_FINAL_FIELD = "staticFinal".toUpperCase();
+        }
+
+        void throwRuntimeException() {
+            throw new IllegalStateException("runtime");
+        }
+
+        int throwFromIntMethod() {
+            throw new IllegalStateException("int");
+        }
+
+        void throwCheckedException() throws TestException {
+            throw new TestException("checked");
+        }
+
+        void throwError() {
+            throw new TestError("error");
+        }
+
+        static void throwFromStaticMethod() throws IOException {
+            throw new IOException("static");
+        }
+
+        private String privateMethod() {
+            return "privateMethod";
+        }
+
+        private static String privateStaticMethod() {
+            return "privateStaticMethod";
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    @Test
+    public void testRuntimeExceptionPropagatesUnwrapped() throws Exception {
+        final Thrower obj = new Thrower();
+        final Method method = Narcissus.findMethod(Thrower.class, "throwRuntimeException");
+        try {
+            Narcissus.invokeVoidMethod(obj, method);
+            fail("throwRuntimeException() should have thrown");
+        } catch (final IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("runtime");
+        }
+    }
+
+    @Test
+    public void testCheckedExceptionPropagatesUnwrapped() throws Exception {
+        final Thrower obj = new Thrower();
+        final Method method = Narcissus.findMethod(Thrower.class, "throwCheckedException");
+        try {
+            Narcissus.invokeVoidMethod(obj, method);
+            fail("throwCheckedException() should have thrown");
+        } catch (final Throwable t) {
+            // A checked exception is thrown without being declared, and without being wrapped
+            assertThat(t).isInstanceOf(TestException.class);
+            assertThat(t.getMessage()).isEqualTo("checked");
+        }
+    }
+
+    @Test
+    public void testErrorPropagatesUnwrapped() throws Exception {
+        final Thrower obj = new Thrower();
+        final Method method = Narcissus.findMethod(Thrower.class, "throwError");
+        try {
+            Narcissus.invokeVoidMethod(obj, method);
+            fail("throwError() should have thrown");
+        } catch (final TestError e) {
+            assertThat(e.getMessage()).isEqualTo("error");
+        }
+    }
+
+    @Test
+    public void testExceptionFromATypedInvokerPropagates() throws Exception {
+        final Thrower obj = new Thrower();
+        final Method method = Narcissus.findMethod(Thrower.class, "throwFromIntMethod");
+        try {
+            Narcissus.invokeIntMethod(obj, method);
+            fail("throwFromIntMethod() should have thrown");
+        } catch (final IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("int");
+        }
+        // The exception also propagates through the boxing wrapper
+        try {
+            Narcissus.invokeMethod(obj, method);
+            fail("throwFromIntMethod() should have thrown");
+        } catch (final IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("int");
+        }
+    }
+
+    @Test
+    public void testExceptionFromAStaticMethodPropagates() throws Exception {
+        final Method method = Narcissus.findMethod(Thrower.class, "throwFromStaticMethod");
+        try {
+            Narcissus.invokeStaticVoidMethod(method);
+            fail("throwFromStaticMethod() should have thrown");
+        } catch (final Throwable t) {
+            assertThat(t).isInstanceOf(IOException.class);
+            assertThat(t.getMessage()).isEqualTo("static");
+        }
+    }
+
+    @Test
+    public void testInvokePrivateMethods() throws Exception {
+        final Thrower obj = new Thrower();
+        assertThat(Narcissus.invokeMethod(obj, Narcissus.findMethod(Thrower.class, "privateMethod")))
+                .isEqualTo("privateMethod");
+        assertThat(Narcissus.invokeStaticMethod(Narcissus.findMethod(Thrower.class, "privateStaticMethod")))
+                .isEqualTo("privateStaticMethod");
+    }
+
+    @Test
+    public void testReadAndWritePrivateFields() throws Exception {
+        final Thrower obj = new Thrower();
+        final Field privateField = Narcissus.findField(Thrower.class, "privateField");
+        assertThat(Narcissus.getField(obj, privateField)).isEqualTo("private");
+        Narcissus.setField(obj, privateField, "changed");
+        assertThat(Narcissus.getField(obj, privateField)).isEqualTo("changed");
+
+        final Field privateStaticField = Narcissus.findField(Thrower.class, "privateStaticField");
+        assertThat(Narcissus.getStaticField(privateStaticField)).isEqualTo("privateStatic");
+        Narcissus.setStaticField(privateStaticField, "changedStatic");
+        assertThat(Narcissus.getStaticField(privateStaticField)).isEqualTo("changedStatic");
+    }
+
+    @Test
+    public void testWriteFinalFields() throws Exception {
+        final Thrower obj = new Thrower();
+        final Field finalField = Narcissus.findField(Thrower.class, "finalField");
+        Narcissus.setField(obj, finalField, "changed");
+        assertThat(Narcissus.getField(obj, finalField)).isEqualTo("changed");
+
+        final Field privateFinalIntField = Narcissus.findField(Thrower.class, "privateFinalIntField");
+        Narcissus.setIntField(obj, privateFinalIntField, 42);
+        assertThat(Narcissus.getIntField(obj, privateFinalIntField)).isEqualTo(42);
+    }
+
+    @Test
+    public void testWriteStaticFinalField() throws Exception {
+        final Field field = Narcissus.findField(Thrower.class, "STATIC_FINAL_FIELD");
+        final Object originalValue = Narcissus.getStaticField(field);
+        assertThat(originalValue).isEqualTo("STATICFINAL");
+        try {
+            Narcissus.setStaticField(field, "changed");
+            assertThat(Narcissus.getStaticField(field)).isEqualTo("changed");
+        } finally {
+            Narcissus.setStaticField(field, originalValue);
+        }
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusFieldModifierMismatchTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusFieldModifierMismatchTest.java
@@ -1,0 +1,379 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+
+/**
+ * Tests that field accessors reject a field with the wrong static modifier, and that instance field accessors
+ * reject an object that is not an instance of the class that declares the field.
+ *
+ * <p>
+ * Without the static modifier check, a static field accessed through the instance accessors is read at the static
+ * field's offset relative to the object header, which reads unrelated memory. Without the receiver check, a field
+ * of an unrelated class is read at that field's offset in an object that may be smaller than the offset.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusFieldModifierMismatchTest {
+
+    /** A class with one instance field and one static field of every type. */
+    public static class Fields {
+        int intField = 1;
+        long longField = 2L;
+        short shortField = 3;
+        char charField = 'a';
+        boolean booleanField = true;
+        byte byteField = 4;
+        float floatField = 5.0f;
+        double doubleField = 6.0;
+        Object objectField = "seven";
+
+        static int staticIntField = 1;
+        static long staticLongField = 2L;
+        static short staticShortField = 3;
+        static char staticCharField = 'a';
+        static boolean staticBooleanField = true;
+        static byte staticByteField = 4;
+        static float staticFloatField = 5.0f;
+        static double staticDoubleField = 6.0;
+        static Object staticObjectField = "seven";
+    }
+
+    /** A class that declares no field of {@link Fields}, for use as a mismatched receiver. */
+    public static class Unrelated {
+        int unrelatedField = 1;
+    }
+
+    /** A subclass of {@link Fields}, which is a valid receiver for the fields of {@link Fields}. */
+    public static class FieldsSubclass extends Fields {
+        int subclassField = 100;
+    }
+
+    /** The names of the accessor types, in the order they are indexed by the loops below. */
+    private static final String[] KINDS = { "int", "long", "short", "char", "boolean", "byte", "float", "double",
+            "object" };
+
+    /** The names of the instance fields of {@link Fields}, in the same order as {@link #KINDS}. */
+    private static final String[] INSTANCE_FIELD_NAMES = { "intField", "longField", "shortField", "charField",
+            "booleanField", "byteField", "floatField", "doubleField", "objectField" };
+
+    /** The names of the static fields of {@link Fields}, in the same order as {@link #KINDS}. */
+    private static final String[] STATIC_FIELD_NAMES = { "staticIntField", "staticLongField", "staticShortField",
+            "staticCharField", "staticBooleanField", "staticByteField", "staticFloatField", "staticDoubleField",
+            "staticObjectField" };
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    /**
+     * Read an instance field using the accessor of the given kind.
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the accessor to use
+     * @param obj
+     *            the object to read the field from
+     * @param field
+     *            the field to read
+     */
+    private static void get(final int kind, final Object obj, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.getIntField(obj, field);
+            break;
+        case 1:
+            Narcissus.getLongField(obj, field);
+            break;
+        case 2:
+            Narcissus.getShortField(obj, field);
+            break;
+        case 3:
+            Narcissus.getCharField(obj, field);
+            break;
+        case 4:
+            Narcissus.getBooleanField(obj, field);
+            break;
+        case 5:
+            Narcissus.getByteField(obj, field);
+            break;
+        case 6:
+            Narcissus.getFloatField(obj, field);
+            break;
+        case 7:
+            Narcissus.getDoubleField(obj, field);
+            break;
+        default:
+            Narcissus.getObjectField(obj, field);
+            break;
+        }
+    }
+
+    /**
+     * Write an instance field using the accessor of the given kind, writing the zero value of that type.
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the accessor to use
+     * @param obj
+     *            the object to write the field in
+     * @param field
+     *            the field to write
+     */
+    private static void set(final int kind, final Object obj, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.setIntField(obj, field, 0);
+            break;
+        case 1:
+            Narcissus.setLongField(obj, field, 0L);
+            break;
+        case 2:
+            Narcissus.setShortField(obj, field, (short) 0);
+            break;
+        case 3:
+            Narcissus.setCharField(obj, field, '\0');
+            break;
+        case 4:
+            Narcissus.setBooleanField(obj, field, false);
+            break;
+        case 5:
+            Narcissus.setByteField(obj, field, (byte) 0);
+            break;
+        case 6:
+            Narcissus.setFloatField(obj, field, 0.0f);
+            break;
+        case 7:
+            Narcissus.setDoubleField(obj, field, 0.0);
+            break;
+        default:
+            Narcissus.setObjectField(obj, field, null);
+            break;
+        }
+    }
+
+    /**
+     * Read a static field using the accessor of the given kind.
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the accessor to use
+     * @param field
+     *            the field to read
+     */
+    private static void getStatic(final int kind, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.getStaticIntField(field);
+            break;
+        case 1:
+            Narcissus.getStaticLongField(field);
+            break;
+        case 2:
+            Narcissus.getStaticShortField(field);
+            break;
+        case 3:
+            Narcissus.getStaticCharField(field);
+            break;
+        case 4:
+            Narcissus.getStaticBooleanField(field);
+            break;
+        case 5:
+            Narcissus.getStaticByteField(field);
+            break;
+        case 6:
+            Narcissus.getStaticFloatField(field);
+            break;
+        case 7:
+            Narcissus.getStaticDoubleField(field);
+            break;
+        default:
+            Narcissus.getStaticObjectField(field);
+            break;
+        }
+    }
+
+    /**
+     * Write a static field using the accessor of the given kind, writing the zero value of that type.
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the accessor to use
+     * @param field
+     *            the field to write
+     */
+    private static void setStatic(final int kind, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.setStaticIntField(field, 0);
+            break;
+        case 1:
+            Narcissus.setStaticLongField(field, 0L);
+            break;
+        case 2:
+            Narcissus.setStaticShortField(field, (short) 0);
+            break;
+        case 3:
+            Narcissus.setStaticCharField(field, '\0');
+            break;
+        case 4:
+            Narcissus.setStaticBooleanField(field, false);
+            break;
+        case 5:
+            Narcissus.setStaticByteField(field, (byte) 0);
+            break;
+        case 6:
+            Narcissus.setStaticFloatField(field, 0.0f);
+            break;
+        case 7:
+            Narcissus.setStaticDoubleField(field, 0.0);
+            break;
+        default:
+            Narcissus.setStaticObjectField(field, null);
+            break;
+        }
+    }
+
+    @Test
+    public void testInstanceAccessorsRejectStaticField() throws Exception {
+        final Fields obj = new Fields();
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Field field = Narcissus.findField(Fields.class, STATIC_FIELD_NAMES[kind]);
+            try {
+                get(kind, obj, field);
+                fail("get" + KINDS[kind] + "Field() should have rejected a static field");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+            try {
+                set(kind, obj, field);
+                fail("set" + KINDS[kind] + "Field() should have rejected a static field");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+        }
+    }
+
+    @Test
+    public void testStaticAccessorsRejectInstanceField() throws Exception {
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Field field = Narcissus.findField(Fields.class, INSTANCE_FIELD_NAMES[kind]);
+            try {
+                getStatic(kind, field);
+                fail("getStatic" + KINDS[kind] + "Field() should have rejected a non-static field");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+            try {
+                setStatic(kind, field);
+                fail("setStatic" + KINDS[kind] + "Field() should have rejected a non-static field");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+        }
+    }
+
+    @Test
+    public void testInstanceAccessorsRejectUnrelatedReceiver() throws Exception {
+        final Unrelated obj = new Unrelated();
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Field field = Narcissus.findField(Fields.class, INSTANCE_FIELD_NAMES[kind]);
+            try {
+                get(kind, obj, field);
+                fail("get" + KINDS[kind] + "Field() should have rejected an unrelated receiver");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+            try {
+                set(kind, obj, field);
+                fail("set" + KINDS[kind] + "Field() should have rejected an unrelated receiver");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+        }
+    }
+
+    @Test
+    public void testInstanceAccessorsAcceptSubclassReceiver() throws Exception {
+        final FieldsSubclass obj = new FieldsSubclass();
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Field field = Narcissus.findField(Fields.class, INSTANCE_FIELD_NAMES[kind]);
+            // A subclass instance is a valid receiver for a superclass field
+            get(kind, obj, field);
+            set(kind, obj, field);
+        }
+        assertThat(obj.intField).isEqualTo(0);
+        assertThat(obj.objectField).isNull();
+        assertThat(obj.subclassField).isEqualTo(100);
+    }
+
+    @Test
+    public void testGetFieldRejectsStaticField() throws Exception {
+        final Fields obj = new Fields();
+        final Field field = Narcissus.findField(Fields.class, "staticIntField");
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                Narcissus.getField(obj, field);
+            }
+        });
+        assertThat(e.getMessage()).contains("getStaticField");
+    }
+
+    @Test
+    public void testSetFieldRejectsStaticField() throws Exception {
+        final Fields obj = new Fields();
+        final Field field = Narcissus.findField(Fields.class, "staticIntField");
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                Narcissus.setField(obj, field, Integer.valueOf(0));
+            }
+        });
+        assertThat(e.getMessage()).contains("setStaticField");
+    }
+
+    @Test
+    public void testGetStaticFieldRejectsInstanceField() throws Exception {
+        final Field field = Narcissus.findField(Fields.class, "intField");
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                Narcissus.getStaticField(field);
+            }
+        });
+        assertThat(e.getMessage()).contains("getField");
+    }
+
+    @Test
+    public void testSetStaticFieldRejectsInstanceField() throws Exception {
+        final Field field = Narcissus.findField(Fields.class, "intField");
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                Narcissus.setStaticField(field, Integer.valueOf(0));
+            }
+        });
+        assertThat(e.getMessage()).contains("setField");
+    }
+
+    @Test
+    public void testGetFieldAndGetStaticFieldReturnEveryFieldType() throws Exception {
+        final Fields obj = new Fields();
+        final Object[] expectedInstanceValues = { Integer.valueOf(1), Long.valueOf(2L), Short.valueOf((short) 3),
+                Character.valueOf('a'), Boolean.TRUE, Byte.valueOf((byte) 4), Float.valueOf(5.0f),
+                Double.valueOf(6.0), "seven" };
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Field instanceField = Narcissus.findField(Fields.class, INSTANCE_FIELD_NAMES[kind]);
+            assertThat(Narcissus.getField(obj, instanceField)).isEqualTo(expectedInstanceValues[kind]);
+            final Field staticField = Narcissus.findField(Fields.class, STATIC_FIELD_NAMES[kind]);
+            assertThat(Narcissus.getStaticField(staticField)).isEqualTo(expectedInstanceValues[kind]);
+        }
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusFieldShadowingTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusFieldShadowingTest.java
@@ -1,0 +1,112 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests that when a field of a subclass shadows a field of the same name in a superclass, the field of the
+ * subclass is the one found, both by {@link Narcissus#findField(Class, String)} and by
+ * {@link ReflectionCache#getField(String)}.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusFieldShadowingTest {
+
+    /** A superclass with a field that a subclass shadows. */
+    public static class Base {
+        String shadowed = "base";
+        String notShadowed = "base";
+        static String staticShadowed = "base";
+    }
+
+    /** A subclass that shadows two of the fields of {@link Base}. */
+    public static class Sub extends Base {
+        String shadowed = "sub";
+        static String staticShadowed = "sub";
+    }
+
+    /** A subclass of {@link Sub}, so that a field is shadowed twice over. */
+    public static class SubSub extends Sub {
+        String shadowed = "subsub";
+    }
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    @Test
+    public void testFindFieldReturnsTheShadowingField() throws Exception {
+        assertThat(Narcissus.findField(Sub.class, "shadowed").getDeclaringClass()).isSameAs(Sub.class);
+        assertThat(Narcissus.findField(SubSub.class, "shadowed").getDeclaringClass()).isSameAs(SubSub.class);
+        assertThat(Narcissus.findField(Base.class, "shadowed").getDeclaringClass()).isSameAs(Base.class);
+        assertThat(Narcissus.findField(Sub.class, "notShadowed").getDeclaringClass()).isSameAs(Base.class);
+    }
+
+    @Test
+    public void testReflectionCacheReturnsTheShadowingField() {
+        assertThat(new ReflectionCache(Sub.class).getField("shadowed").getDeclaringClass()).isSameAs(Sub.class);
+        assertThat(new ReflectionCache(SubSub.class).getField("shadowed").getDeclaringClass())
+                .isSameAs(SubSub.class);
+        assertThat(new ReflectionCache(Base.class).getField("shadowed").getDeclaringClass()).isSameAs(Base.class);
+        assertThat(new ReflectionCache(Sub.class).getField("notShadowed").getDeclaringClass()).isSameAs(Base.class);
+        assertThat(new ReflectionCache(Sub.class).getField("staticShadowed").getDeclaringClass())
+                .isSameAs(Sub.class);
+    }
+
+    @Test
+    public void testReflectionCacheAndFindFieldAgree() throws Exception {
+        final ReflectionCache cache = new ReflectionCache(SubSub.class);
+        final String[] fieldNames = { "shadowed", "notShadowed", "staticShadowed" };
+        for (int i = 0; i < fieldNames.length; i++) {
+            assertThat(cache.getField(fieldNames[i])).isEqualTo(Narcissus.findField(SubSub.class, fieldNames[i]));
+        }
+    }
+
+    @Test
+    public void testTheShadowingAndShadowedFieldsAreDistinctStorage() throws Exception {
+        final SubSub obj = new SubSub();
+        final Field subSubField = Narcissus.findField(SubSub.class, "shadowed");
+        final Field subField = Narcissus.findField(Sub.class, "shadowed");
+        final Field baseField = Narcissus.findField(Base.class, "shadowed");
+        assertThat(Narcissus.getField(obj, subSubField)).isEqualTo("subsub");
+        assertThat(Narcissus.getField(obj, subField)).isEqualTo("sub");
+        assertThat(Narcissus.getField(obj, baseField)).isEqualTo("base");
+
+        Narcissus.setField(obj, baseField, "changed");
+        assertThat(Narcissus.getField(obj, baseField)).isEqualTo("changed");
+        assertThat(Narcissus.getField(obj, subField)).isEqualTo("sub");
+        assertThat(Narcissus.getField(obj, subSubField)).isEqualTo("subsub");
+    }
+
+    @Test
+    public void testEnumerateFieldsListsSubclassFieldsFirst() {
+        final List<Field> fields = Narcissus.enumerateFields(SubSub.class);
+        int subSubIdx = -1;
+        int subIdx = -1;
+        int baseIdx = -1;
+        for (int i = 0; i < fields.size(); i++) {
+            final Field field = fields.get(i);
+            if (field.getName().equals("shadowed")) {
+                if (field.getDeclaringClass() == SubSub.class) {
+                    subSubIdx = i;
+                } else if (field.getDeclaringClass() == Sub.class) {
+                    subIdx = i;
+                } else if (field.getDeclaringClass() == Base.class) {
+                    baseIdx = i;
+                }
+            }
+        }
+        // All three fields named "shadowed" are listed, subclass first
+        assertThat(subSubIdx).isGreaterThanOrEqualTo(0);
+        assertThat(subIdx).isGreaterThan(subSubIdx);
+        assertThat(baseIdx).isGreaterThan(subIdx);
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusFieldTypeMismatchTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusFieldTypeMismatchTest.java
@@ -1,0 +1,389 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+
+/**
+ * Tests that a typed field accessor rejects a field whose declared type does not match the accessor type.
+ *
+ * <p>
+ * Without this check, e.g. calling {@code getLongField()} on an {@code int} field reads eight bytes from the offset
+ * of a four-byte field, which reads past the end of the object, and calling {@code setObjectField()} on a
+ * primitive field writes a reference into a primitive slot, which corrupts the heap and crashes the JVM in the
+ * next garbage collection.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusFieldTypeMismatchTest {
+
+    /** A class with one instance field and one static field of every type. */
+    public static class AllTypes {
+        int intField = 1;
+        long longField = 2L;
+        short shortField = 3;
+        char charField = 'a';
+        boolean booleanField = true;
+        byte byteField = 4;
+        float floatField = 5.0f;
+        double doubleField = 6.0;
+        Object objectField = "seven";
+
+        static int staticIntField = 1;
+        static long staticLongField = 2L;
+        static short staticShortField = 3;
+        static char staticCharField = 'a';
+        static boolean staticBooleanField = true;
+        static byte staticByteField = 4;
+        static float staticFloatField = 5.0f;
+        static double staticDoubleField = 6.0;
+        static Object staticObjectField = "seven";
+    }
+
+    /** A class with fields of several different reference types. */
+    public static class ReferenceTypes {
+        String stringField = "str";
+        Integer boxedIntField = Integer.valueOf(1);
+        int[] intArrayField = { 1, 2, 3 };
+        String[] stringArrayField = { "a" };
+        CharSequence charSequenceField = "cs";
+
+        static String staticStringField = "str";
+    }
+
+    /** The names of the accessor types, in the order they are indexed by the loops below. */
+    private static final String[] KINDS = { "int", "long", "short", "char", "boolean", "byte", "float", "double",
+            "object" };
+
+    /** The names of the instance fields of {@link AllTypes}, in the same order as {@link #KINDS}. */
+    private static final String[] INSTANCE_FIELD_NAMES = { "intField", "longField", "shortField", "charField",
+            "booleanField", "byteField", "floatField", "doubleField", "objectField" };
+
+    /** The names of the static fields of {@link AllTypes}, in the same order as {@link #KINDS}. */
+    private static final String[] STATIC_FIELD_NAMES = { "staticIntField", "staticLongField", "staticShortField",
+            "staticCharField", "staticBooleanField", "staticByteField", "staticFloatField", "staticDoubleField",
+            "staticObjectField" };
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    /**
+     * Read an instance field using the accessor of the given kind.
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the accessor to use
+     * @param obj
+     *            the object to read the field from
+     * @param field
+     *            the field to read
+     * @return the field value, boxed
+     */
+    private static Object get(final int kind, final Object obj, final Field field) {
+        switch (kind) {
+        case 0:
+            return Integer.valueOf(Narcissus.getIntField(obj, field));
+        case 1:
+            return Long.valueOf(Narcissus.getLongField(obj, field));
+        case 2:
+            return Short.valueOf(Narcissus.getShortField(obj, field));
+        case 3:
+            return Character.valueOf(Narcissus.getCharField(obj, field));
+        case 4:
+            return Boolean.valueOf(Narcissus.getBooleanField(obj, field));
+        case 5:
+            return Byte.valueOf(Narcissus.getByteField(obj, field));
+        case 6:
+            return Float.valueOf(Narcissus.getFloatField(obj, field));
+        case 7:
+            return Double.valueOf(Narcissus.getDoubleField(obj, field));
+        default:
+            return Narcissus.getObjectField(obj, field);
+        }
+    }
+
+    /**
+     * Write an instance field using the accessor of the given kind, writing the zero value of that type.
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the accessor to use
+     * @param obj
+     *            the object to write the field in
+     * @param field
+     *            the field to write
+     */
+    private static void set(final int kind, final Object obj, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.setIntField(obj, field, 0);
+            break;
+        case 1:
+            Narcissus.setLongField(obj, field, 0L);
+            break;
+        case 2:
+            Narcissus.setShortField(obj, field, (short) 0);
+            break;
+        case 3:
+            Narcissus.setCharField(obj, field, '\0');
+            break;
+        case 4:
+            Narcissus.setBooleanField(obj, field, false);
+            break;
+        case 5:
+            Narcissus.setByteField(obj, field, (byte) 0);
+            break;
+        case 6:
+            Narcissus.setFloatField(obj, field, 0.0f);
+            break;
+        case 7:
+            Narcissus.setDoubleField(obj, field, 0.0);
+            break;
+        default:
+            Narcissus.setObjectField(obj, field, null);
+            break;
+        }
+    }
+
+    /**
+     * Read a static field using the accessor of the given kind.
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the accessor to use
+     * @param field
+     *            the field to read
+     * @return the field value, boxed
+     */
+    private static Object getStatic(final int kind, final Field field) {
+        switch (kind) {
+        case 0:
+            return Integer.valueOf(Narcissus.getStaticIntField(field));
+        case 1:
+            return Long.valueOf(Narcissus.getStaticLongField(field));
+        case 2:
+            return Short.valueOf(Narcissus.getStaticShortField(field));
+        case 3:
+            return Character.valueOf(Narcissus.getStaticCharField(field));
+        case 4:
+            return Boolean.valueOf(Narcissus.getStaticBooleanField(field));
+        case 5:
+            return Byte.valueOf(Narcissus.getStaticByteField(field));
+        case 6:
+            return Float.valueOf(Narcissus.getStaticFloatField(field));
+        case 7:
+            return Double.valueOf(Narcissus.getStaticDoubleField(field));
+        default:
+            return Narcissus.getStaticObjectField(field);
+        }
+    }
+
+    /**
+     * Write a static field using the accessor of the given kind, writing the zero value of that type.
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the accessor to use
+     * @param field
+     *            the field to write
+     */
+    private static void setStatic(final int kind, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.setStaticIntField(field, 0);
+            break;
+        case 1:
+            Narcissus.setStaticLongField(field, 0L);
+            break;
+        case 2:
+            Narcissus.setStaticShortField(field, (short) 0);
+            break;
+        case 3:
+            Narcissus.setStaticCharField(field, '\0');
+            break;
+        case 4:
+            Narcissus.setStaticBooleanField(field, false);
+            break;
+        case 5:
+            Narcissus.setStaticByteField(field, (byte) 0);
+            break;
+        case 6:
+            Narcissus.setStaticFloatField(field, 0.0f);
+            break;
+        case 7:
+            Narcissus.setStaticDoubleField(field, 0.0);
+            break;
+        default:
+            Narcissus.setStaticObjectField(field, null);
+            break;
+        }
+    }
+
+    @Test
+    public void testInstanceGetterRejectsMismatchedFieldType() throws Exception {
+        final AllTypes obj = new AllTypes();
+        for (int fieldKind = 0; fieldKind < KINDS.length; fieldKind++) {
+            final Field field = Narcissus.findField(AllTypes.class, INSTANCE_FIELD_NAMES[fieldKind]);
+            for (int accessorKind = 0; accessorKind < KINDS.length; accessorKind++) {
+                if (accessorKind == fieldKind) {
+                    // The matching accessor must work
+                    get(accessorKind, obj, field);
+                } else {
+                    try {
+                        get(accessorKind, obj, field);
+                        fail("get" + KINDS[accessorKind] + "Field() should have rejected a field of type "
+                                + KINDS[fieldKind]);
+                    } catch (final IllegalArgumentException e) {
+                        // Expected
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testInstanceSetterRejectsMismatchedFieldType() throws Exception {
+        for (int fieldKind = 0; fieldKind < KINDS.length; fieldKind++) {
+            final Field field = Narcissus.findField(AllTypes.class, INSTANCE_FIELD_NAMES[fieldKind]);
+            for (int accessorKind = 0; accessorKind < KINDS.length; accessorKind++) {
+                // Use a fresh object for each write, so that a write that succeeds cannot affect a later case
+                final AllTypes obj = new AllTypes();
+                if (accessorKind == fieldKind) {
+                    set(accessorKind, obj, field);
+                } else {
+                    try {
+                        set(accessorKind, obj, field);
+                        fail("set" + KINDS[accessorKind] + "Field() should have rejected a field of type "
+                                + KINDS[fieldKind]);
+                    } catch (final IllegalArgumentException e) {
+                        // Expected
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testStaticGetterRejectsMismatchedFieldType() throws Exception {
+        for (int fieldKind = 0; fieldKind < KINDS.length; fieldKind++) {
+            final Field field = Narcissus.findField(AllTypes.class, STATIC_FIELD_NAMES[fieldKind]);
+            for (int accessorKind = 0; accessorKind < KINDS.length; accessorKind++) {
+                if (accessorKind == fieldKind) {
+                    getStatic(accessorKind, field);
+                } else {
+                    try {
+                        getStatic(accessorKind, field);
+                        fail("getStatic" + KINDS[accessorKind] + "Field() should have rejected a field of type "
+                                + KINDS[fieldKind]);
+                    } catch (final IllegalArgumentException e) {
+                        // Expected
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testStaticSetterRejectsMismatchedFieldType() throws Exception {
+        for (int fieldKind = 0; fieldKind < KINDS.length; fieldKind++) {
+            final Field field = Narcissus.findField(AllTypes.class, STATIC_FIELD_NAMES[fieldKind]);
+            for (int accessorKind = 0; accessorKind < KINDS.length; accessorKind++) {
+                if (accessorKind == fieldKind) {
+                    setStatic(accessorKind, field);
+                } else {
+                    try {
+                        setStatic(accessorKind, field);
+                        fail("setStatic" + KINDS[accessorKind] + "Field() should have rejected a field of type "
+                                + KINDS[fieldKind]);
+                    } catch (final IllegalArgumentException e) {
+                        // Expected
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testObjectAccessorsWorkForEveryReferenceType() throws Exception {
+        final ReferenceTypes obj = new ReferenceTypes();
+        final String[] fieldNames = { "stringField", "boxedIntField", "intArrayField", "stringArrayField",
+                "charSequenceField" };
+        for (final String fieldName : fieldNames) {
+            final Field field = Narcissus.findField(ReferenceTypes.class, fieldName);
+            assertThat(Narcissus.getObjectField(obj, field)).isNotNull();
+            Narcissus.setObjectField(obj, field, null);
+            assertThat(Narcissus.getObjectField(obj, field)).isNull();
+        }
+    }
+
+    @Test
+    public void testSetObjectFieldRejectsValueOfIncompatibleType() throws Exception {
+        final ReferenceTypes obj = new ReferenceTypes();
+        final Field field = Narcissus.findField(ReferenceTypes.class, "stringField");
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                Narcissus.setObjectField(obj, field, Integer.valueOf(1));
+            }
+        });
+        // The field must be unchanged
+        assertThat(obj.stringField).isEqualTo("str");
+    }
+
+    @Test
+    public void testSetObjectFieldAcceptsSubtypeOfFieldType() throws Exception {
+        final ReferenceTypes obj = new ReferenceTypes();
+        final Field field = Narcissus.findField(ReferenceTypes.class, "charSequenceField");
+        Narcissus.setObjectField(obj, field, "a String is a CharSequence");
+        assertThat(obj.charSequenceField).isEqualTo("a String is a CharSequence");
+    }
+
+    @Test
+    public void testSetStaticObjectFieldRejectsValueOfIncompatibleType() throws Exception {
+        final Field field = Narcissus.findField(ReferenceTypes.class, "staticStringField");
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                Narcissus.setStaticObjectField(field, Integer.valueOf(1));
+            }
+        });
+    }
+
+    @Test
+    public void testSetObjectFieldAcceptsNullForAnyReferenceType() throws Exception {
+        final ReferenceTypes obj = new ReferenceTypes();
+        final Field field = Narcissus.findField(ReferenceTypes.class, "intArrayField");
+        Narcissus.setObjectField(obj, field, null);
+        assertThat(obj.intArrayField).isNull();
+    }
+
+    @Test
+    public void testSetObjectFieldRejectsNullForPrimitiveField() throws Exception {
+        final AllTypes obj = new AllTypes();
+        final Field field = Narcissus.findField(AllTypes.class, "intField");
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                Narcissus.setObjectField(obj, field, null);
+            }
+        });
+        assertThat(obj.intField).isEqualTo(1);
+    }
+
+    @Test
+    public void testSetStaticObjectFieldRejectsNullForPrimitiveField() throws Exception {
+        final Field field = Narcissus.findField(AllTypes.class, "staticIntField");
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                Narcissus.setStaticObjectField(field, null);
+            }
+        });
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusFieldValueConversionTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusFieldValueConversionTest.java
@@ -1,0 +1,228 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests the unboxing of the value passed to {@link Narcissus#setField(Object, Field, Object)} and
+ * {@link Narcissus#setStaticField(Field, Object)}: widening primitive conversion (JLS 5.1.2) is applied where the
+ * language allows it, and any other value is rejected with an {@link IllegalArgumentException}.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusFieldValueConversionTest {
+
+    /** A class with one instance field and one static field of each primitive type, plus an Object field. */
+    public static class Fields {
+        boolean booleanField;
+        byte byteField;
+        char charField;
+        short shortField;
+        int intField;
+        long longField;
+        float floatField;
+        double doubleField;
+        Object objectField;
+
+        static boolean staticBooleanField;
+        static byte staticByteField;
+        static char staticCharField;
+        static short staticShortField;
+        static int staticIntField;
+        static long staticLongField;
+        static float staticFloatField;
+        static double staticDoubleField;
+        static Object staticObjectField;
+    }
+
+    /** The names of the primitive types, in the order they are indexed by the loops below. */
+    private static final String[] KINDS = { "boolean", "byte", "char", "short", "int", "long", "float", "double" };
+
+    /** The names of the instance fields of {@link Fields}, in the same order as {@link #KINDS}. */
+    private static final String[] INSTANCE_FIELD_NAMES = { "booleanField", "byteField", "charField", "shortField",
+            "intField", "longField", "floatField", "doubleField" };
+
+    /** The names of the static fields of {@link Fields}, in the same order as {@link #KINDS}. */
+    private static final String[] STATIC_FIELD_NAMES = { "staticBooleanField", "staticByteField", "staticCharField",
+            "staticShortField", "staticIntField", "staticLongField", "staticFloatField", "staticDoubleField" };
+
+    /** One boxed value of each primitive type, in the same order as {@link #KINDS}. */
+    private static final Object[] VALUES = { Boolean.TRUE, Byte.valueOf((byte) 7), Character.valueOf('A'),
+            Short.valueOf((short) 7), Integer.valueOf(7), Long.valueOf(7L), Float.valueOf(7.5f),
+            Double.valueOf(7.5) };
+
+    /**
+     * {@code WIDENS_TO[valKind]} has bit {@code fieldKind} set if a value of type {@code valKind} can be assigned
+     * to a field of type {@code fieldKind} by widening primitive conversion (JLS 5.1.2).
+     */
+    private static final int[] WIDENS_TO = { //
+            1 << 0, // boolean -> boolean
+            1 << 1 | 1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7, // byte -> byte, short, int, long, float, double
+            1 << 2 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7, // char -> char, int, long, float, double
+            1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7, // short -> short, int, long, float, double
+            1 << 4 | 1 << 5 | 1 << 6 | 1 << 7, // int -> int, long, float, double
+            1 << 5 | 1 << 6 | 1 << 7, // long -> long, float, double
+            1 << 6 | 1 << 7, // float -> float, double
+            1 << 7 // double -> double
+    };
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    /**
+     * Convert the value of the given kind to the boxed form a field of the given kind should hold after the value
+     * is assigned to it.
+     *
+     * @param valKind
+     *            the index into {@link #KINDS} of the type of the value
+     * @param fieldKind
+     *            the index into {@link #KINDS} of the type of the field
+     * @return the value the field is expected to hold
+     */
+    private static Object widened(final int valKind, final int fieldKind) {
+        if (fieldKind == 0) {
+            return Boolean.TRUE;
+        }
+        final double numericVal = valKind == 2 ? 'A' : ((Number) VALUES[valKind]).doubleValue();
+        switch (fieldKind) {
+        case 1:
+            return Byte.valueOf((byte) numericVal);
+        case 2:
+            return Character.valueOf((char) numericVal);
+        case 3:
+            return Short.valueOf((short) numericVal);
+        case 4:
+            return Integer.valueOf((int) numericVal);
+        case 5:
+            return Long.valueOf((long) numericVal);
+        case 6:
+            return Float.valueOf((float) numericVal);
+        default:
+            return Double.valueOf(numericVal);
+        }
+    }
+
+    @Test
+    public void testSetFieldAppliesWideningPrimitiveConversion() throws Exception {
+        final Fields obj = new Fields();
+        for (int fieldKind = 0; fieldKind < KINDS.length; fieldKind++) {
+            final Field field = Narcissus.findField(Fields.class, INSTANCE_FIELD_NAMES[fieldKind]);
+            for (int valKind = 0; valKind < KINDS.length; valKind++) {
+                if ((WIDENS_TO[valKind] & (1 << fieldKind)) != 0) {
+                    Narcissus.setField(obj, field, VALUES[valKind]);
+                    assertThat(Narcissus.getField(obj, field)).isEqualTo(widened(valKind, fieldKind));
+                } else {
+                    try {
+                        Narcissus.setField(obj, field, VALUES[valKind]);
+                        fail("setField() should have rejected a " + KINDS[valKind] + " value for a "
+                                + KINDS[fieldKind] + " field");
+                    } catch (final IllegalArgumentException e) {
+                        assertThat(e.getMessage()).contains(KINDS[fieldKind]);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSetStaticFieldAppliesWideningPrimitiveConversion() throws Exception {
+        for (int fieldKind = 0; fieldKind < KINDS.length; fieldKind++) {
+            final Field field = Narcissus.findField(Fields.class, STATIC_FIELD_NAMES[fieldKind]);
+            for (int valKind = 0; valKind < KINDS.length; valKind++) {
+                if ((WIDENS_TO[valKind] & (1 << fieldKind)) != 0) {
+                    Narcissus.setStaticField(field, VALUES[valKind]);
+                    assertThat(Narcissus.getStaticField(field)).isEqualTo(widened(valKind, fieldKind));
+                } else {
+                    try {
+                        Narcissus.setStaticField(field, VALUES[valKind]);
+                        fail("setStaticField() should have rejected a " + KINDS[valKind] + " value for a "
+                                + KINDS[fieldKind] + " field");
+                    } catch (final IllegalArgumentException e) {
+                        assertThat(e.getMessage()).contains(KINDS[fieldKind]);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSetFieldRejectsNullForPrimitiveField() throws Exception {
+        final Fields obj = new Fields();
+        for (int fieldKind = 0; fieldKind < KINDS.length; fieldKind++) {
+            final Field instanceField = Narcissus.findField(Fields.class, INSTANCE_FIELD_NAMES[fieldKind]);
+            try {
+                Narcissus.setField(obj, instanceField, null);
+                fail("setField() should have rejected a null value for a " + KINDS[fieldKind] + " field");
+            } catch (final IllegalArgumentException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+            final Field staticField = Narcissus.findField(Fields.class, STATIC_FIELD_NAMES[fieldKind]);
+            try {
+                Narcissus.setStaticField(staticField, null);
+                fail("setStaticField() should have rejected a null value for a " + KINDS[fieldKind] + " field");
+            } catch (final IllegalArgumentException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+        }
+    }
+
+    @Test
+    public void testSetFieldRejectsValueThatIsNotABoxedPrimitive() throws Exception {
+        // Types that are Numbers, but are not boxed primitive types, must not be unboxed
+        final Object[] nonBoxedValues = { "7", new BigInteger("7"), new BigDecimal("7.5"), new AtomicInteger(7),
+                new int[] { 7 }, new Object() };
+        final Fields obj = new Fields();
+        for (int fieldKind = 0; fieldKind < KINDS.length; fieldKind++) {
+            final Field field = Narcissus.findField(Fields.class, INSTANCE_FIELD_NAMES[fieldKind]);
+            for (int i = 0; i < nonBoxedValues.length; i++) {
+                try {
+                    Narcissus.setField(obj, field, nonBoxedValues[i]);
+                    fail("setField() should have rejected a " + nonBoxedValues[i].getClass().getName()
+                            + " value for a " + KINDS[fieldKind] + " field");
+                } catch (final IllegalArgumentException e) {
+                    assertThat(e.getMessage()).contains(nonBoxedValues[i].getClass().getName());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSetFieldAcceptsNullAndSubtypesForReferenceField() throws Exception {
+        final Fields obj = new Fields();
+        final Field field = Narcissus.findField(Fields.class, "objectField");
+        Narcissus.setField(obj, field, "abc");
+        assertThat(obj.objectField).isEqualTo("abc");
+        Narcissus.setField(obj, field, null);
+        assertThat(obj.objectField).isNull();
+
+        final Field staticField = Narcissus.findField(Fields.class, "staticObjectField");
+        Narcissus.setStaticField(staticField, Integer.valueOf(1));
+        assertThat(Fields.staticObjectField).isEqualTo(Integer.valueOf(1));
+        Narcissus.setStaticField(staticField, null);
+        assertThat(Fields.staticObjectField).isNull();
+    }
+
+    @Test
+    public void testExceptionMessageNamesTheValueTypeAndTheField() throws Exception {
+        final Fields obj = new Fields();
+        final Field field = Narcissus.findField(Fields.class, "intField");
+        try {
+            Narcissus.setField(obj, field, "abc");
+            fail("setField() should have rejected a String value for an int field");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("java.lang.String").contains("intField").contains("int");
+        }
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusFindClassTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusFindClassTest.java
@@ -1,0 +1,127 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/** Tests {@link Narcissus#findClass(String)} for every form of class name it accepts. */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusFindClassTest {
+
+    /** A nested class, to test lookup of a class whose binary name contains a '$'. */
+    public static class Nested {
+    }
+
+    /** The names of the primitive types, and void. */
+    private static final String[] PRIMITIVE_NAMES = { "boolean", "byte", "char", "short", "int", "long", "float",
+            "double", "void" };
+
+    /** The primitive type classes, in the same order as {@link #PRIMITIVE_NAMES}. */
+    private static final Class<?>[] PRIMITIVE_CLASSES = { boolean.class, byte.class, char.class, short.class,
+            int.class, long.class, float.class, double.class, void.class };
+
+    /** One-dimensional array classes of each primitive type, in the same order as {@link #PRIMITIVE_NAMES}. */
+    private static final Class<?>[] PRIMITIVE_ARRAY_CLASSES = { boolean[].class, byte[].class, char[].class,
+            short[].class, int[].class, long[].class, float[].class, double[].class, null };
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    @Test
+    public void testFindPrimitiveClasses() {
+        for (int i = 0; i < PRIMITIVE_NAMES.length; i++) {
+            assertThat(Narcissus.findClass(PRIMITIVE_NAMES[i])).isSameAs(PRIMITIVE_CLASSES[i]);
+        }
+    }
+
+    @Test
+    public void testFindPrimitiveArrayClasses() {
+        for (int i = 0; i < PRIMITIVE_NAMES.length; i++) {
+            if (PRIMITIVE_ARRAY_CLASSES[i] == null) {
+                // There is no void[] type
+                continue;
+            }
+            assertThat(Narcissus.findClass(PRIMITIVE_NAMES[i] + "[]")).isSameAs(PRIMITIVE_ARRAY_CLASSES[i]);
+        }
+        assertThat(Narcissus.findClass("int[][]")).isSameAs(int[][].class);
+        assertThat(Narcissus.findClass("int[][][]")).isSameAs(int[][][].class);
+    }
+
+    @Test
+    public void testFindReferenceClasses() {
+        assertThat(Narcissus.findClass("java.lang.String")).isSameAs(String.class);
+        assertThat(Narcissus.findClass("java.util.Map")).isSameAs(Map.class);
+        assertThat(Narcissus.findClass(NarcissusFindClassTest.class.getName()))
+                .isSameAs(NarcissusFindClassTest.class);
+    }
+
+    @Test
+    public void testFindNestedClass() {
+        // The binary name of a nested class contains a '$'
+        assertThat(Narcissus.findClass(Nested.class.getName())).isSameAs(Nested.class);
+        assertThat(Narcissus.findClass("java.util.Map$Entry")).isSameAs(Map.Entry.class);
+    }
+
+    @Test
+    public void testFindReferenceArrayClasses() {
+        assertThat(Narcissus.findClass("java.lang.String[]")).isSameAs(String[].class);
+        assertThat(Narcissus.findClass("java.lang.String[][]")).isSameAs(String[][].class);
+        assertThat(Narcissus.findClass(Nested.class.getName() + "[]")).isSameAs(Nested[].class);
+    }
+
+    @Test
+    public void testFindClassAcceptsInternalNameForm() {
+        // Class names are converted to internal form, so both forms work
+        assertThat(Narcissus.findClass("java/lang/String")).isSameAs(String.class);
+        assertThat(Narcissus.findClass("java/lang/String[]")).isSameAs(String[].class);
+    }
+
+    @Test
+    public void testFindClassRejectsNull() {
+        try {
+            Narcissus.findClass(null);
+            fail("findClass(null) should have thrown IllegalArgumentException");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("null");
+        }
+    }
+
+    @Test
+    public void testFindNonexistentClass() {
+        try {
+            Narcissus.findClass("no.such.Class");
+            fail("findClass() should have thrown NoClassDefFoundError for a nonexistent class");
+        } catch (final NoClassDefFoundError e) {
+            assertThat(e.getMessage()).contains("no/such/Class");
+        }
+    }
+
+    @Test
+    public void testFindNonexistentArrayClass() {
+        try {
+            Narcissus.findClass("no.such.Class[]");
+            fail("findClass() should have thrown NoClassDefFoundError for a nonexistent array class");
+        } catch (final NoClassDefFoundError e) {
+            assertThat(e.getMessage()).contains("no/such/Class");
+        }
+    }
+
+    @Test
+    public void testFindClassWithEmptyName() {
+        try {
+            Narcissus.findClass("");
+            fail("findClass(\"\") should have thrown an error");
+        } catch (final NoClassDefFoundError e) {
+            // Expected
+        }
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusFindMemberTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusFindMemberTest.java
@@ -1,0 +1,255 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests the member lookup methods when the member does not exist, and tests the private native lookup methods that
+ * {@link Narcissus#findClass(String)} and the class initializer are built on.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusFindMemberTest {
+
+    /** A class with a small, known set of members. */
+    public static class Members {
+        int intField;
+        static String staticStringField = "x";
+
+        int method(final int val) {
+            return val;
+        }
+
+        static int staticMethod(final int val) {
+            return val;
+        }
+
+        /** Constructor. */
+        public Members() {
+        }
+
+        /**
+         * Constructor.
+         *
+         * @param val
+         *            an argument
+         */
+        public Members(final int val) {
+        }
+    }
+
+    /** An interface, which has no constructors. */
+    public interface AnInterface {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    /**
+     * Invoke one of the private native lookup methods of {@link Narcissus}, using Narcissus itself.
+     *
+     * @param methodName
+     *            the name of the native method
+     * @param paramTypes
+     *            the parameter types of the native method
+     * @param args
+     *            the arguments to pass
+     * @return the result of the invocation
+     * @throws NoSuchMethodException
+     *             if the native method is not found
+     */
+    private static Object invokeInternal(final String methodName, final Class<?>[] paramTypes, final Object... args)
+            throws NoSuchMethodException {
+        final Method method = Narcissus.findMethod(Narcissus.class, methodName, paramTypes);
+        return Narcissus.invokeStaticObjectMethod(method, args);
+    }
+
+    @Test
+    public void testFindMethodWithUnknownName() {
+        try {
+            Narcissus.findMethod(Members.class, "noSuchMethod");
+            fail("findMethod() should have thrown NoSuchMethodException");
+        } catch (final NoSuchMethodException e) {
+            assertThat(e.getMessage()).contains("noSuchMethod");
+        }
+    }
+
+    @Test
+    public void testFindMethodWithWrongParameterTypes() {
+        try {
+            Narcissus.findMethod(Members.class, "method", String.class);
+            fail("findMethod() should have thrown NoSuchMethodException");
+        } catch (final NoSuchMethodException e) {
+            assertThat(e.getMessage()).contains("method");
+        }
+        try {
+            Narcissus.findMethod(Members.class, "method");
+            fail("findMethod() should have thrown NoSuchMethodException when given no parameter types");
+        } catch (final NoSuchMethodException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testFindFieldWithUnknownName() {
+        try {
+            Narcissus.findField(Members.class, "noSuchField");
+            fail("findField() should have thrown NoSuchFieldException");
+        } catch (final NoSuchFieldException e) {
+            assertThat(e.getMessage()).contains("noSuchField");
+        }
+    }
+
+    @Test
+    public void testFindConstructorWithWrongParameterTypes() {
+        try {
+            Narcissus.findConstructor(Members.class, String.class);
+            fail("findConstructor() should have thrown NoSuchMethodException");
+        } catch (final NoSuchMethodException e) {
+            assertThat(e.getMessage()).contains("Members");
+        }
+    }
+
+    @Test
+    public void testFindConstructorOfAnInterface() {
+        try {
+            Narcissus.findConstructor(AnInterface.class);
+            fail("findConstructor() should have thrown NoSuchMethodException for an interface");
+        } catch (final NoSuchMethodException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testFindConstructorsThatDoExist() throws Exception {
+        assertThat(Narcissus.findConstructor(Members.class).getParameterTypes()).isEmpty();
+        assertThat(Narcissus.findConstructor(Members.class, int.class).getParameterTypes())
+                .containsExactly(int.class);
+    }
+
+    @Test
+    public void testFindMethodInternal() throws Exception {
+        final Class<?>[] paramTypes = { Class.class, String.class, String.class, boolean.class };
+        final Method found = (Method) invokeInternal("findMethodInternal", paramTypes, Members.class, "method",
+                "(I)I", Boolean.FALSE);
+        assertThat(found).isEqualTo(Narcissus.findMethod(Members.class, "method", int.class));
+
+        final Method foundStatic = (Method) invokeInternal("findMethodInternal", paramTypes, Members.class,
+                "staticMethod", "(I)I", Boolean.TRUE);
+        assertThat(foundStatic).isEqualTo(Narcissus.findMethod(Members.class, "staticMethod", int.class));
+    }
+
+    @Test
+    public void testFindMethodInternalWithUnknownMethod() throws Exception {
+        final Class<?>[] paramTypes = { Class.class, String.class, String.class, boolean.class };
+        try {
+            invokeInternal("findMethodInternal", paramTypes, Members.class, "noSuchMethod", "()V", Boolean.FALSE);
+            fail("findMethodInternal() should have thrown NoSuchMethodError");
+        } catch (final NoSuchMethodError e) {
+            // Expected -- the pending exception from GetMethodID() is thrown when the native method returns
+        }
+    }
+
+    @Test
+    public void testFindMethodInternalWithWrongStaticModifier() throws Exception {
+        final Class<?>[] paramTypes = { Class.class, String.class, String.class, boolean.class };
+        try {
+            invokeInternal("findMethodInternal", paramTypes, Members.class, "method", "(I)I", Boolean.TRUE);
+            fail("findMethodInternal() should have thrown NoSuchMethodError for a non-static method");
+        } catch (final NoSuchMethodError e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testFindMethodInternalWithNullArgs() throws Exception {
+        final Class<?>[] paramTypes = { Class.class, String.class, String.class, boolean.class };
+        final Object[][] argsWithANull = { { null, "method", "(I)I", Boolean.FALSE },
+                { Members.class, null, "(I)I", Boolean.FALSE }, { Members.class, "method", null, Boolean.FALSE } };
+        for (int i = 0; i < argsWithANull.length; i++) {
+            try {
+                invokeInternal("findMethodInternal", paramTypes, argsWithANull[i]);
+                fail("findMethodInternal() should have thrown NullPointerException for a null argument");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+        }
+    }
+
+    @Test
+    public void testFindFieldInternal() throws Exception {
+        final Class<?>[] paramTypes = { Class.class, String.class, String.class, boolean.class };
+        final Field found = (Field) invokeInternal("findFieldInternal", paramTypes, Members.class, "intField", "I",
+                Boolean.FALSE);
+        assertThat(found).isEqualTo(Narcissus.findField(Members.class, "intField"));
+
+        final Field foundStatic = (Field) invokeInternal("findFieldInternal", paramTypes, Members.class,
+                "staticStringField", "Ljava/lang/String;", Boolean.TRUE);
+        assertThat(foundStatic).isEqualTo(Narcissus.findField(Members.class, "staticStringField"));
+    }
+
+    @Test
+    public void testFindFieldInternalWithUnknownFieldOrWrongSignature() throws Exception {
+        final Class<?>[] paramTypes = { Class.class, String.class, String.class, boolean.class };
+        try {
+            invokeInternal("findFieldInternal", paramTypes, Members.class, "noSuchField", "I", Boolean.FALSE);
+            fail("findFieldInternal() should have thrown NoSuchFieldError");
+        } catch (final NoSuchFieldError e) {
+            // Expected
+        }
+        try {
+            // The field exists, but its type is int, not long
+            invokeInternal("findFieldInternal", paramTypes, Members.class, "intField", "J", Boolean.FALSE);
+            fail("findFieldInternal() should have thrown NoSuchFieldError for a wrong signature");
+        } catch (final NoSuchFieldError e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testFindFieldInternalWithNullArgs() throws Exception {
+        final Class<?>[] paramTypes = { Class.class, String.class, String.class, boolean.class };
+        final Object[][] argsWithANull = { { null, "intField", "I", Boolean.FALSE },
+                { Members.class, null, "I", Boolean.FALSE }, { Members.class, "intField", null, Boolean.FALSE } };
+        for (int i = 0; i < argsWithANull.length; i++) {
+            try {
+                invokeInternal("findFieldInternal", paramTypes, argsWithANull[i]);
+                fail("findFieldInternal() should have thrown NullPointerException for a null argument");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+        }
+    }
+
+    @Test
+    public void testFindClassInternalWithNullName() throws Exception {
+        final Class<?>[] paramTypes = { String.class };
+        try {
+            invokeInternal("findClassInternal", paramTypes, new Object[] { null });
+            fail("findClassInternal() should have thrown NullPointerException");
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage()).contains("null");
+        }
+    }
+
+    @Test
+    public void testGetDeclaredMembersOfArrayAndPrimitiveClasses() {
+        // An array class and a primitive class declare no members of their own
+        assertThat(Narcissus.getDeclaredFields(int[].class)).isEmpty();
+        assertThat(Narcissus.getDeclaredMethods(int[].class)).isEmpty();
+        assertThat(Narcissus.getDeclaredConstructors(int[].class)).isEmpty();
+        assertThat(Narcissus.getDeclaredFields(int.class)).isEmpty();
+        assertThat(Narcissus.getDeclaredMethods(int.class)).isEmpty();
+        assertThat(Narcissus.getDeclaredConstructors(int.class)).isEmpty();
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusManyParametersTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusManyParametersTest.java
@@ -1,0 +1,157 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests invocation of a method with the maximum number of parameters a method can have. A method descriptor may
+ * declare at most 255 argument slots (JVMS 4.3.3), and one of those slots is taken by {@code this} for an instance
+ * method, so a static method taking 255 int parameters is the widest call that can be made.
+ *
+ * <p>
+ * The arguments are unboxed into a fixed-size buffer of 255 jvalues, so this exercises the last entry of that
+ * buffer.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusManyParametersTest {
+
+    /** The maximum number of argument slots in a method descriptor. */
+    private static final int MAX_PARAMS = 255;
+
+    /** A class with a static method taking the maximum possible number of parameters. */
+    public static class ManyParams {
+    static int sum255(final int p0, final int p1, final int p2, final int p3, final int p4, final int p5,
+            final int p6, final int p7, final int p8, final int p9, final int p10, final int p11, final int p12,
+            final int p13, final int p14, final int p15, final int p16, final int p17, final int p18,
+            final int p19, final int p20, final int p21, final int p22, final int p23, final int p24,
+            final int p25, final int p26, final int p27, final int p28, final int p29, final int p30,
+            final int p31, final int p32, final int p33, final int p34, final int p35, final int p36,
+            final int p37, final int p38, final int p39, final int p40, final int p41, final int p42,
+            final int p43, final int p44, final int p45, final int p46, final int p47, final int p48,
+            final int p49, final int p50, final int p51, final int p52, final int p53, final int p54,
+            final int p55, final int p56, final int p57, final int p58, final int p59, final int p60,
+            final int p61, final int p62, final int p63, final int p64, final int p65, final int p66,
+            final int p67, final int p68, final int p69, final int p70, final int p71, final int p72,
+            final int p73, final int p74, final int p75, final int p76, final int p77, final int p78,
+            final int p79, final int p80, final int p81, final int p82, final int p83, final int p84,
+            final int p85, final int p86, final int p87, final int p88, final int p89, final int p90,
+            final int p91, final int p92, final int p93, final int p94, final int p95, final int p96,
+            final int p97, final int p98, final int p99, final int p100, final int p101, final int p102,
+            final int p103, final int p104, final int p105, final int p106, final int p107, final int p108,
+            final int p109, final int p110, final int p111, final int p112, final int p113, final int p114,
+            final int p115, final int p116, final int p117, final int p118, final int p119, final int p120,
+            final int p121, final int p122, final int p123, final int p124, final int p125, final int p126,
+            final int p127, final int p128, final int p129, final int p130, final int p131, final int p132,
+            final int p133, final int p134, final int p135, final int p136, final int p137, final int p138,
+            final int p139, final int p140, final int p141, final int p142, final int p143, final int p144,
+            final int p145, final int p146, final int p147, final int p148, final int p149, final int p150,
+            final int p151, final int p152, final int p153, final int p154, final int p155, final int p156,
+            final int p157, final int p158, final int p159, final int p160, final int p161, final int p162,
+            final int p163, final int p164, final int p165, final int p166, final int p167, final int p168,
+            final int p169, final int p170, final int p171, final int p172, final int p173, final int p174,
+            final int p175, final int p176, final int p177, final int p178, final int p179, final int p180,
+            final int p181, final int p182, final int p183, final int p184, final int p185, final int p186,
+            final int p187, final int p188, final int p189, final int p190, final int p191, final int p192,
+            final int p193, final int p194, final int p195, final int p196, final int p197, final int p198,
+            final int p199, final int p200, final int p201, final int p202, final int p203, final int p204,
+            final int p205, final int p206, final int p207, final int p208, final int p209, final int p210,
+            final int p211, final int p212, final int p213, final int p214, final int p215, final int p216,
+            final int p217, final int p218, final int p219, final int p220, final int p221, final int p222,
+            final int p223, final int p224, final int p225, final int p226, final int p227, final int p228,
+            final int p229, final int p230, final int p231, final int p232, final int p233, final int p234,
+            final int p235, final int p236, final int p237, final int p238, final int p239, final int p240,
+            final int p241, final int p242, final int p243, final int p244, final int p245, final int p246,
+            final int p247, final int p248, final int p249, final int p250, final int p251, final int p252,
+            final int p253, final int p254) {
+        return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9 + p10 + p11 + p12 + p13 + p14 + p15 + p16 + p17 +
+                p18 + p19 + p20 + p21 + p22 + p23 + p24 + p25 + p26 + p27 + p28 + p29 + p30 + p31 + p32 + p33 +
+                p34 + p35 + p36 + p37 + p38 + p39 + p40 + p41 + p42 + p43 + p44 + p45 + p46 + p47 + p48 + p49 +
+                p50 + p51 + p52 + p53 + p54 + p55 + p56 + p57 + p58 + p59 + p60 + p61 + p62 + p63 + p64 + p65 +
+                p66 + p67 + p68 + p69 + p70 + p71 + p72 + p73 + p74 + p75 + p76 + p77 + p78 + p79 + p80 + p81 +
+                p82 + p83 + p84 + p85 + p86 + p87 + p88 + p89 + p90 + p91 + p92 + p93 + p94 + p95 + p96 + p97 +
+                p98 + p99 + p100 + p101 + p102 + p103 + p104 + p105 + p106 + p107 + p108 + p109 + p110 + p111 +
+                p112 + p113 + p114 + p115 + p116 + p117 + p118 + p119 + p120 + p121 + p122 + p123 + p124 + p125 +
+                p126 + p127 + p128 + p129 + p130 + p131 + p132 + p133 + p134 + p135 + p136 + p137 + p138 + p139 +
+                p140 + p141 + p142 + p143 + p144 + p145 + p146 + p147 + p148 + p149 + p150 + p151 + p152 + p153 +
+                p154 + p155 + p156 + p157 + p158 + p159 + p160 + p161 + p162 + p163 + p164 + p165 + p166 + p167 +
+                p168 + p169 + p170 + p171 + p172 + p173 + p174 + p175 + p176 + p177 + p178 + p179 + p180 + p181 +
+                p182 + p183 + p184 + p185 + p186 + p187 + p188 + p189 + p190 + p191 + p192 + p193 + p194 + p195 +
+                p196 + p197 + p198 + p199 + p200 + p201 + p202 + p203 + p204 + p205 + p206 + p207 + p208 + p209 +
+                p210 + p211 + p212 + p213 + p214 + p215 + p216 + p217 + p218 + p219 + p220 + p221 + p222 + p223 +
+                p224 + p225 + p226 + p227 + p228 + p229 + p230 + p231 + p232 + p233 + p234 + p235 + p236 + p237 +
+                p238 + p239 + p240 + p241 + p242 + p243 + p244 + p245 + p246 + p247 + p248 + p249 + p250 + p251 +
+                p252 + p253 + p254;
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    /**
+     * Find the widest method.
+     *
+     * @return the method taking {@link #MAX_PARAMS} int parameters
+     * @throws NoSuchMethodException
+     *             if the method is not found
+     */
+    private static Method findSum255() throws NoSuchMethodException {
+        final Class<?>[] paramTypes = new Class<?>[MAX_PARAMS];
+        Arrays.fill(paramTypes, int.class);
+        return Narcissus.findMethod(ManyParams.class, "sum255", paramTypes);
+    }
+
+    @Test
+    public void testInvokeMethodWithMaximumNumberOfParameters() throws Exception {
+        final Method method = findSum255();
+        final Object[] args = new Object[MAX_PARAMS];
+        for (int i = 0; i < args.length; i++) {
+            args[i] = Integer.valueOf(i);
+        }
+        assertThat(Narcissus.invokeStaticIntMethod(method, args))
+                .isEqualTo((MAX_PARAMS - 1) * MAX_PARAMS / 2);
+        assertThat(Narcissus.invokeStaticMethod(method, args))
+                .isEqualTo(Integer.valueOf((MAX_PARAMS - 1) * MAX_PARAMS / 2));
+    }
+
+    @Test
+    public void testLastParameterIsCheckedToo() throws Exception {
+        final Method method = findSum255();
+        final Object[] args = new Object[MAX_PARAMS];
+        for (int i = 0; i < args.length; i++) {
+            args[i] = Integer.valueOf(i);
+        }
+        args[MAX_PARAMS - 1] = "not an int";
+        try {
+            Narcissus.invokeStaticIntMethod(method, args);
+            fail("sum255() should have rejected a String as its last argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong type");
+        }
+    }
+
+    @Test
+    public void testTooManyArgumentsForTheWidestMethod() throws Exception {
+        final Method method = findSum255();
+        final Object[] args = new Object[MAX_PARAMS + 1];
+        for (int i = 0; i < args.length; i++) {
+            args[i] = Integer.valueOf(i);
+        }
+        try {
+            Narcissus.invokeStaticIntMethod(method, args);
+            fail("sum255() should have rejected a call with too many arguments");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong number of arguments");
+        }
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusMethodArgumentTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusMethodArgumentTest.java
@@ -1,0 +1,281 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests the conversion of method invocation arguments: widening primitive conversion of boxed arguments, rejection
+ * of arguments of the wrong type, rejection of a null argument for a primitive parameter, and rejection of a call
+ * with the wrong number of arguments.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusMethodArgumentTest {
+
+    /** A class with one method taking a single parameter of each primitive type, plus reference-typed methods. */
+    public static class Params {
+        static boolean takeBoolean(final boolean val) {
+            return val;
+        }
+
+        static byte takeByte(final byte val) {
+            return val;
+        }
+
+        static char takeChar(final char val) {
+            return val;
+        }
+
+        static short takeShort(final short val) {
+            return val;
+        }
+
+        static int takeInt(final int val) {
+            return val;
+        }
+
+        static long takeLong(final long val) {
+            return val;
+        }
+
+        static float takeFloat(final float val) {
+            return val;
+        }
+
+        static double takeDouble(final double val) {
+            return val;
+        }
+
+        static String takeCharSequence(final CharSequence val) {
+            return String.valueOf(val);
+        }
+
+        static String takeNothing() {
+            return "nothing";
+        }
+
+        static String takeTwo(final int first, final String second) {
+            return first + ":" + second;
+        }
+
+        int instanceTakeInt(final int val) {
+            return val;
+        }
+    }
+
+    /** The names of the primitive types, in the order they are indexed by the loops below. */
+    private static final String[] KINDS = { "boolean", "byte", "char", "short", "int", "long", "float", "double" };
+
+    /** The names of the methods of {@link Params} taking one primitive parameter, in the same order. */
+    private static final String[] METHOD_NAMES = { "takeBoolean", "takeByte", "takeChar", "takeShort", "takeInt",
+            "takeLong", "takeFloat", "takeDouble" };
+
+    /** The parameter types of those methods, in the same order. */
+    private static final Class<?>[] PARAM_TYPES = { boolean.class, byte.class, char.class, short.class, int.class,
+            long.class, float.class, double.class };
+
+    /** One boxed argument value of each primitive type, in the same order as {@link #KINDS}. */
+    private static final Object[] ARG_VALUES = { Boolean.TRUE, Byte.valueOf((byte) 7), Character.valueOf('A'),
+            Short.valueOf((short) 7), Integer.valueOf(7), Long.valueOf(7L), Float.valueOf(7.5f),
+            Double.valueOf(7.5) };
+
+    /**
+     * {@code WIDENS_TO[argKind]} has bit {@code paramKind} set if an argument of type {@code argKind} can be passed
+     * to a parameter of type {@code paramKind} by widening primitive conversion (JLS 5.1.2).
+     */
+    private static final int[] WIDENS_TO = { //
+            1 << 0, // boolean -> boolean
+            1 << 1 | 1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7, // byte -> byte, short, int, long, float, double
+            1 << 2 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7, // char -> char, int, long, float, double
+            1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7, // short -> short, int, long, float, double
+            1 << 4 | 1 << 5 | 1 << 6 | 1 << 7, // int -> int, long, float, double
+            1 << 5 | 1 << 6 | 1 << 7, // long -> long, float, double
+            1 << 6 | 1 << 7, // float -> float, double
+            1 << 7 // double -> double
+    };
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    /**
+     * Convert the argument value of the given kind to the boxed form the parameter of the given kind should receive
+     * it in.
+     *
+     * @param argKind
+     *            the index into {@link #KINDS} of the type of the argument
+     * @param paramKind
+     *            the index into {@link #KINDS} of the type of the parameter
+     * @return the value the invoked method is expected to return
+     */
+    private static Object widened(final int argKind, final int paramKind) {
+        if (paramKind == 0) {
+            return Boolean.TRUE;
+        }
+        final double numericVal = argKind == 2 ? 'A' : ((Number) ARG_VALUES[argKind]).doubleValue();
+        switch (paramKind) {
+        case 1:
+            return Byte.valueOf((byte) numericVal);
+        case 2:
+            return Character.valueOf((char) numericVal);
+        case 3:
+            return Short.valueOf((short) numericVal);
+        case 4:
+            return Integer.valueOf((int) numericVal);
+        case 5:
+            return Long.valueOf((long) numericVal);
+        case 6:
+            return Float.valueOf((float) numericVal);
+        default:
+            return Double.valueOf(numericVal);
+        }
+    }
+
+    @Test
+    public void testWideningPrimitiveConversionOfArguments() throws Exception {
+        for (int paramKind = 0; paramKind < KINDS.length; paramKind++) {
+            final Method method = Narcissus.findMethod(Params.class, METHOD_NAMES[paramKind],
+                    PARAM_TYPES[paramKind]);
+            for (int argKind = 0; argKind < KINDS.length; argKind++) {
+                final boolean widens = (WIDENS_TO[argKind] & (1 << paramKind)) != 0;
+                if (widens) {
+                    assertThat(Narcissus.invokeStaticMethod(method, ARG_VALUES[argKind]))
+                            .isEqualTo(widened(argKind, paramKind));
+                } else {
+                    try {
+                        Narcissus.invokeStaticMethod(method, ARG_VALUES[argKind]);
+                        fail(METHOD_NAMES[paramKind] + "() should have rejected a " + KINDS[argKind] + " argument");
+                    } catch (final IllegalArgumentException e) {
+                        assertThat(e.getMessage()).contains("wrong type");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testPrimitiveParameterRejectsNullArgument() throws Exception {
+        for (int paramKind = 0; paramKind < KINDS.length; paramKind++) {
+            final Method method = Narcissus.findMethod(Params.class, METHOD_NAMES[paramKind],
+                    PARAM_TYPES[paramKind]);
+            try {
+                Narcissus.invokeStaticMethod(method, new Object[] { null });
+                fail(METHOD_NAMES[paramKind] + "() should have rejected a null argument");
+            } catch (final IllegalArgumentException e) {
+                assertThat(e.getMessage()).contains("null argument");
+            }
+        }
+    }
+
+    @Test
+    public void testPrimitiveParameterRejectsNonBoxedArgument() throws Exception {
+        // Types that are Numbers, but are not boxed primitive types, must not be unboxed
+        final Object[] nonBoxedValues = { "7", new java.math.BigInteger("7"), new java.math.BigDecimal("7.5"),
+                new AtomicInteger(7), new int[] { 7 }, new Object() };
+        for (int paramKind = 0; paramKind < KINDS.length; paramKind++) {
+            final Method method = Narcissus.findMethod(Params.class, METHOD_NAMES[paramKind],
+                    PARAM_TYPES[paramKind]);
+            for (int i = 0; i < nonBoxedValues.length; i++) {
+                try {
+                    Narcissus.invokeStaticMethod(method, nonBoxedValues[i]);
+                    fail(METHOD_NAMES[paramKind] + "() should have rejected an argument of type "
+                            + nonBoxedValues[i].getClass().getName());
+                } catch (final IllegalArgumentException e) {
+                    assertThat(e.getMessage()).contains("wrong type");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testWrongNumberOfArguments() throws Exception {
+        final Method takeInt = Narcissus.findMethod(Params.class, "takeInt", int.class);
+        try {
+            Narcissus.invokeStaticMethod(takeInt);
+            fail("takeInt() should have rejected a call with no arguments");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong number of arguments");
+        }
+        try {
+            Narcissus.invokeStaticMethod(takeInt, Integer.valueOf(1), Integer.valueOf(2));
+            fail("takeInt() should have rejected a call with two arguments");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong number of arguments");
+        }
+
+        final Method takeNothing = Narcissus.findMethod(Params.class, "takeNothing");
+        try {
+            Narcissus.invokeStaticMethod(takeNothing, Integer.valueOf(1));
+            fail("takeNothing() should have rejected a call with one argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong number of arguments");
+        }
+    }
+
+    @Test
+    public void testNullArgsArrayIsTreatedAsNoArguments() throws Exception {
+        final Method takeNothing = Narcissus.findMethod(Params.class, "takeNothing");
+        assertThat(Narcissus.invokeStaticObjectMethod(takeNothing, (Object[]) null)).isEqualTo("nothing");
+
+        final Method takeInt = Narcissus.findMethod(Params.class, "takeInt", int.class);
+        try {
+            Narcissus.invokeStaticIntMethod(takeInt, (Object[]) null);
+            fail("takeInt() should have rejected a null args array");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong number of arguments");
+        }
+    }
+
+    @Test
+    public void testReferenceParameterAcceptsNullAndSubtypes() throws Exception {
+        final Method method = Narcissus.findMethod(Params.class, "takeCharSequence", CharSequence.class);
+        assertThat(Narcissus.invokeStaticMethod(method, new Object[] { null })).isEqualTo("null");
+        assertThat(Narcissus.invokeStaticMethod(method, "abc")).isEqualTo("abc");
+        assertThat(Narcissus.invokeStaticMethod(method, new StringBuilder("def"))).isEqualTo("def");
+    }
+
+    @Test
+    public void testReferenceParameterRejectsIncompatibleType() throws Exception {
+        final Method method = Narcissus.findMethod(Params.class, "takeCharSequence", CharSequence.class);
+        try {
+            Narcissus.invokeStaticMethod(method, Integer.valueOf(1));
+            fail("takeCharSequence() should have rejected an Integer argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("incompatible type");
+        }
+    }
+
+    @Test
+    public void testMultipleParameters() throws Exception {
+        final Method method = Narcissus.findMethod(Params.class, "takeTwo", int.class, String.class);
+        assertThat(Narcissus.invokeStaticMethod(method, Byte.valueOf((byte) 3), "x")).isEqualTo("3:x");
+        try {
+            Narcissus.invokeStaticMethod(method, "x", Integer.valueOf(3));
+            fail("takeTwo() should have rejected arguments in the wrong order");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong type");
+        }
+    }
+
+    @Test
+    public void testArgumentsOfInstanceMethodAreConvertedTheSameWay() throws Exception {
+        final Params obj = new Params();
+        final Method method = Narcissus.findMethod(Params.class, "instanceTakeInt", int.class);
+        assertThat(Narcissus.invokeIntMethod(obj, method, Short.valueOf((short) 9))).isEqualTo(9);
+        try {
+            Narcissus.invokeIntMethod(obj, method, Long.valueOf(9L));
+            fail("instanceTakeInt() should have rejected a long argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong type");
+        }
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusMethodReturnTypeTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusMethodReturnTypeTest.java
@@ -1,0 +1,336 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests that the typed method invokers reject a method whose return type does not match the invoker's return type,
+ * reject a method with the wrong static modifier, and reject a receiver that is not an instance of the class that
+ * declares the method.
+ *
+ * <p>
+ * Without these checks, the JNI {@code Call<Type>MethodA} function reads the return value of a method as if it had
+ * the invoker's return type, which reads whatever is left in the return register or on the stack.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusMethodReturnTypeTest {
+
+    /** A class with one instance method and one static method returning every possible return type. */
+    public static class Returns {
+        void retVoid() {
+        }
+
+        int retInt() {
+            return 1;
+        }
+
+        long retLong() {
+            return 2L;
+        }
+
+        short retShort() {
+            return 3;
+        }
+
+        char retChar() {
+            return 'a';
+        }
+
+        boolean retBoolean() {
+            return true;
+        }
+
+        byte retByte() {
+            return 4;
+        }
+
+        float retFloat() {
+            return 5.0f;
+        }
+
+        double retDouble() {
+            return 6.0;
+        }
+
+        Object retObject() {
+            return "seven";
+        }
+
+        static void staticRetVoid() {
+        }
+
+        static int staticRetInt() {
+            return 1;
+        }
+
+        static long staticRetLong() {
+            return 2L;
+        }
+
+        static short staticRetShort() {
+            return 3;
+        }
+
+        static char staticRetChar() {
+            return 'a';
+        }
+
+        static boolean staticRetBoolean() {
+            return true;
+        }
+
+        static byte staticRetByte() {
+            return 4;
+        }
+
+        static float staticRetFloat() {
+            return 5.0f;
+        }
+
+        static double staticRetDouble() {
+            return 6.0;
+        }
+
+        static Object staticRetObject() {
+            return "seven";
+        }
+    }
+
+    /** A class that declares none of the methods of {@link Returns}, for use as a mismatched receiver. */
+    public static class Unrelated {
+    }
+
+    /** A subclass of {@link Returns}, which is a valid receiver for the methods of {@link Returns}. */
+    public static class ReturnsSubclass extends Returns {
+    }
+
+    /** The names of the invoker types, in the order they are indexed by the loops below. */
+    private static final String[] KINDS = { "void", "int", "long", "short", "char", "boolean", "byte", "float",
+            "double", "object" };
+
+    /** The names of the instance methods of {@link Returns}, in the same order as {@link #KINDS}. */
+    private static final String[] INSTANCE_METHOD_NAMES = { "retVoid", "retInt", "retLong", "retShort", "retChar",
+            "retBoolean", "retByte", "retFloat", "retDouble", "retObject" };
+
+    /** The names of the static methods of {@link Returns}, in the same order as {@link #KINDS}. */
+    private static final String[] STATIC_METHOD_NAMES = { "staticRetVoid", "staticRetInt", "staticRetLong",
+            "staticRetShort", "staticRetChar", "staticRetBoolean", "staticRetByte", "staticRetFloat",
+            "staticRetDouble", "staticRetObject" };
+
+    /** The values the instance methods of {@link Returns} return, in the same order as {@link #KINDS}. */
+    private static final Object[] RETURN_VALUES = { null, Integer.valueOf(1), Long.valueOf(2L),
+            Short.valueOf((short) 3), Character.valueOf('a'), Boolean.TRUE, Byte.valueOf((byte) 4),
+            Float.valueOf(5.0f), Double.valueOf(6.0), "seven" };
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    /**
+     * Invoke an instance method using the invoker of the given kind, and return the result boxed (or null for the
+     * void invoker).
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the invoker to use
+     * @param obj
+     *            the object to invoke the method on
+     * @param method
+     *            the method to invoke
+     * @return the boxed return value, or null if the void invoker was used
+     */
+    private static Object invoke(final int kind, final Object obj, final Method method) {
+        switch (kind) {
+        case 0:
+            Narcissus.invokeVoidMethod(obj, method);
+            return null;
+        case 1:
+            return Integer.valueOf(Narcissus.invokeIntMethod(obj, method));
+        case 2:
+            return Long.valueOf(Narcissus.invokeLongMethod(obj, method));
+        case 3:
+            return Short.valueOf(Narcissus.invokeShortMethod(obj, method));
+        case 4:
+            return Character.valueOf(Narcissus.invokeCharMethod(obj, method));
+        case 5:
+            return Boolean.valueOf(Narcissus.invokeBooleanMethod(obj, method));
+        case 6:
+            return Byte.valueOf(Narcissus.invokeByteMethod(obj, method));
+        case 7:
+            return Float.valueOf(Narcissus.invokeFloatMethod(obj, method));
+        case 8:
+            return Double.valueOf(Narcissus.invokeDoubleMethod(obj, method));
+        default:
+            return Narcissus.invokeObjectMethod(obj, method);
+        }
+    }
+
+    /**
+     * Invoke a static method using the invoker of the given kind, and return the result boxed (or null for the void
+     * invoker).
+     *
+     * @param kind
+     *            the index into {@link #KINDS} of the invoker to use
+     * @param method
+     *            the method to invoke
+     * @return the boxed return value, or null if the void invoker was used
+     */
+    private static Object invokeStatic(final int kind, final Method method) {
+        switch (kind) {
+        case 0:
+            Narcissus.invokeStaticVoidMethod(method);
+            return null;
+        case 1:
+            return Integer.valueOf(Narcissus.invokeStaticIntMethod(method));
+        case 2:
+            return Long.valueOf(Narcissus.invokeStaticLongMethod(method));
+        case 3:
+            return Short.valueOf(Narcissus.invokeStaticShortMethod(method));
+        case 4:
+            return Character.valueOf(Narcissus.invokeStaticCharMethod(method));
+        case 5:
+            return Boolean.valueOf(Narcissus.invokeStaticBooleanMethod(method));
+        case 6:
+            return Byte.valueOf(Narcissus.invokeStaticByteMethod(method));
+        case 7:
+            return Float.valueOf(Narcissus.invokeStaticFloatMethod(method));
+        case 8:
+            return Double.valueOf(Narcissus.invokeStaticDoubleMethod(method));
+        default:
+            return Narcissus.invokeStaticObjectMethod(method);
+        }
+    }
+
+    @Test
+    public void testInstanceInvokerRequiresMatchingReturnType() throws Exception {
+        final Returns obj = new Returns();
+        for (int methodKind = 0; methodKind < KINDS.length; methodKind++) {
+            final Method method = Narcissus.findMethod(Returns.class, INSTANCE_METHOD_NAMES[methodKind]);
+            for (int invokerKind = 0; invokerKind < KINDS.length; invokerKind++) {
+                if (invokerKind == methodKind) {
+                    assertThat(invoke(invokerKind, obj, method)).isEqualTo(RETURN_VALUES[methodKind]);
+                } else {
+                    try {
+                        invoke(invokerKind, obj, method);
+                        fail("invoke" + KINDS[invokerKind] + "Method() should have rejected a method returning "
+                                + KINDS[methodKind]);
+                    } catch (final IllegalArgumentException e) {
+                        // Expected
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testStaticInvokerRequiresMatchingReturnType() throws Exception {
+        for (int methodKind = 0; methodKind < KINDS.length; methodKind++) {
+            final Method method = Narcissus.findMethod(Returns.class, STATIC_METHOD_NAMES[methodKind]);
+            for (int invokerKind = 0; invokerKind < KINDS.length; invokerKind++) {
+                if (invokerKind == methodKind) {
+                    assertThat(invokeStatic(invokerKind, method)).isEqualTo(RETURN_VALUES[methodKind]);
+                } else {
+                    try {
+                        invokeStatic(invokerKind, method);
+                        fail("invokeStatic" + KINDS[invokerKind]
+                                + "Method() should have rejected a method returning " + KINDS[methodKind]);
+                    } catch (final IllegalArgumentException e) {
+                        // Expected
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testInstanceInvokersRejectStaticMethod() throws Exception {
+        final Returns obj = new Returns();
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Method method = Narcissus.findMethod(Returns.class, STATIC_METHOD_NAMES[kind]);
+            try {
+                invoke(kind, obj, method);
+                fail("invoke" + KINDS[kind] + "Method() should have rejected a static method");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+        }
+    }
+
+    @Test
+    public void testStaticInvokersRejectInstanceMethod() throws Exception {
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Method method = Narcissus.findMethod(Returns.class, INSTANCE_METHOD_NAMES[kind]);
+            try {
+                invokeStatic(kind, method);
+                fail("invokeStatic" + KINDS[kind] + "Method() should have rejected a non-static method");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+        }
+    }
+
+    @Test
+    public void testInstanceInvokersRejectUnrelatedReceiver() throws Exception {
+        final Unrelated obj = new Unrelated();
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Method method = Narcissus.findMethod(Returns.class, INSTANCE_METHOD_NAMES[kind]);
+            try {
+                invoke(kind, obj, method);
+                fail("invoke" + KINDS[kind] + "Method() should have rejected an unrelated receiver");
+            } catch (final IllegalArgumentException e) {
+                // Expected
+            }
+        }
+    }
+
+    @Test
+    public void testInstanceInvokersAcceptSubclassReceiver() throws Exception {
+        final ReturnsSubclass obj = new ReturnsSubclass();
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Method method = Narcissus.findMethod(Returns.class, INSTANCE_METHOD_NAMES[kind]);
+            assertThat(invoke(kind, obj, method)).isEqualTo(RETURN_VALUES[kind]);
+        }
+    }
+
+    @Test
+    public void testInvokeMethodBoxesEveryReturnType() throws Exception {
+        final Returns obj = new Returns();
+        for (int kind = 0; kind < KINDS.length; kind++) {
+            final Method instanceMethod = Narcissus.findMethod(Returns.class, INSTANCE_METHOD_NAMES[kind]);
+            assertThat(Narcissus.invokeMethod(obj, instanceMethod)).isEqualTo(RETURN_VALUES[kind]);
+            final Method staticMethod = Narcissus.findMethod(Returns.class, STATIC_METHOD_NAMES[kind]);
+            assertThat(Narcissus.invokeStaticMethod(staticMethod)).isEqualTo(RETURN_VALUES[kind]);
+        }
+    }
+
+    @Test
+    public void testInvokeMethodRejectsStaticMethod() throws Exception {
+        final Returns obj = new Returns();
+        final Method method = Narcissus.findMethod(Returns.class, "staticRetInt");
+        try {
+            Narcissus.invokeMethod(obj, method);
+            fail("invokeMethod() should have rejected a static method");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("invokeStaticMethod");
+        }
+    }
+
+    @Test
+    public void testInvokeStaticMethodRejectsInstanceMethod() throws Exception {
+        final Method method = Narcissus.findMethod(Returns.class, "retInt");
+        try {
+            Narcissus.invokeStaticMethod(method);
+            fail("invokeStaticMethod() should have rejected a non-static method");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("invokeMethod");
+        }
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusNullArgumentTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusNullArgumentTest.java
@@ -1,0 +1,556 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests that every entry point rejects a null argument with a {@link NullPointerException}, rather than
+ * dereferencing it in native code, which would crash the JVM.
+ *
+ * <p>
+ * Each of the typed field accessors and method invokers is covered, with the null in each argument position in
+ * turn.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusNullArgumentTest {
+
+    /** A class with a field and a method of each type. */
+    public static class Target {
+        int intField;
+        long longField;
+        short shortField;
+        char charField;
+        boolean booleanField;
+        byte byteField;
+        float floatField;
+        double doubleField;
+        Object objectField;
+
+        static int staticIntField;
+        static long staticLongField;
+        static short staticShortField;
+        static char staticCharField;
+        static boolean staticBooleanField;
+        static byte staticByteField;
+        static float staticFloatField;
+        static double staticDoubleField;
+        static Object staticObjectField;
+
+        void retVoid() {
+        }
+
+        int retInt() {
+            return 0;
+        }
+
+        long retLong() {
+            return 0;
+        }
+
+        short retShort() {
+            return 0;
+        }
+
+        char retChar() {
+            return 0;
+        }
+
+        boolean retBoolean() {
+            return false;
+        }
+
+        byte retByte() {
+            return 0;
+        }
+
+        float retFloat() {
+            return 0;
+        }
+
+        double retDouble() {
+            return 0;
+        }
+
+        Object retObject() {
+            return null;
+        }
+    }
+
+    /** The number of typed field accessors, and of typed method invokers minus the void invoker. */
+    private static final int NUM_FIELD_KINDS = 9;
+
+    /** The number of typed method invokers. */
+    private static final int NUM_METHOD_KINDS = 10;
+
+    /** The names of the instance fields of {@link Target}. */
+    private static final String[] FIELD_NAMES = { "intField", "longField", "shortField", "charField",
+            "booleanField", "byteField", "floatField", "doubleField", "objectField" };
+
+    /** The names of the static fields of {@link Target}. */
+    private static final String[] STATIC_FIELD_NAMES = { "staticIntField", "staticLongField", "staticShortField",
+            "staticCharField", "staticBooleanField", "staticByteField", "staticFloatField", "staticDoubleField",
+            "staticObjectField" };
+
+    /** The names of the methods of {@link Target}. */
+    private static final String[] METHOD_NAMES = { "retVoid", "retInt", "retLong", "retShort", "retChar",
+            "retBoolean", "retByte", "retFloat", "retDouble", "retObject" };
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    /**
+     * Read an instance field using the typed accessor of the given kind.
+     *
+     * @param kind
+     *            the accessor to use
+     * @param obj
+     *            the object to read the field from
+     * @param field
+     *            the field to read
+     */
+    private static void getField(final int kind, final Object obj, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.getIntField(obj, field);
+            break;
+        case 1:
+            Narcissus.getLongField(obj, field);
+            break;
+        case 2:
+            Narcissus.getShortField(obj, field);
+            break;
+        case 3:
+            Narcissus.getCharField(obj, field);
+            break;
+        case 4:
+            Narcissus.getBooleanField(obj, field);
+            break;
+        case 5:
+            Narcissus.getByteField(obj, field);
+            break;
+        case 6:
+            Narcissus.getFloatField(obj, field);
+            break;
+        case 7:
+            Narcissus.getDoubleField(obj, field);
+            break;
+        default:
+            Narcissus.getObjectField(obj, field);
+            break;
+        }
+    }
+
+    /**
+     * Write an instance field using the typed accessor of the given kind.
+     *
+     * @param kind
+     *            the accessor to use
+     * @param obj
+     *            the object to write the field in
+     * @param field
+     *            the field to write
+     */
+    private static void setField(final int kind, final Object obj, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.setIntField(obj, field, 0);
+            break;
+        case 1:
+            Narcissus.setLongField(obj, field, 0L);
+            break;
+        case 2:
+            Narcissus.setShortField(obj, field, (short) 0);
+            break;
+        case 3:
+            Narcissus.setCharField(obj, field, '\0');
+            break;
+        case 4:
+            Narcissus.setBooleanField(obj, field, false);
+            break;
+        case 5:
+            Narcissus.setByteField(obj, field, (byte) 0);
+            break;
+        case 6:
+            Narcissus.setFloatField(obj, field, 0.0f);
+            break;
+        case 7:
+            Narcissus.setDoubleField(obj, field, 0.0);
+            break;
+        default:
+            Narcissus.setObjectField(obj, field, null);
+            break;
+        }
+    }
+
+    /**
+     * Read a static field using the typed accessor of the given kind.
+     *
+     * @param kind
+     *            the accessor to use
+     * @param field
+     *            the field to read
+     */
+    private static void getStaticField(final int kind, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.getStaticIntField(field);
+            break;
+        case 1:
+            Narcissus.getStaticLongField(field);
+            break;
+        case 2:
+            Narcissus.getStaticShortField(field);
+            break;
+        case 3:
+            Narcissus.getStaticCharField(field);
+            break;
+        case 4:
+            Narcissus.getStaticBooleanField(field);
+            break;
+        case 5:
+            Narcissus.getStaticByteField(field);
+            break;
+        case 6:
+            Narcissus.getStaticFloatField(field);
+            break;
+        case 7:
+            Narcissus.getStaticDoubleField(field);
+            break;
+        default:
+            Narcissus.getStaticObjectField(field);
+            break;
+        }
+    }
+
+    /**
+     * Write a static field using the typed accessor of the given kind.
+     *
+     * @param kind
+     *            the accessor to use
+     * @param field
+     *            the field to write
+     */
+    private static void setStaticField(final int kind, final Field field) {
+        switch (kind) {
+        case 0:
+            Narcissus.setStaticIntField(field, 0);
+            break;
+        case 1:
+            Narcissus.setStaticLongField(field, 0L);
+            break;
+        case 2:
+            Narcissus.setStaticShortField(field, (short) 0);
+            break;
+        case 3:
+            Narcissus.setStaticCharField(field, '\0');
+            break;
+        case 4:
+            Narcissus.setStaticBooleanField(field, false);
+            break;
+        case 5:
+            Narcissus.setStaticByteField(field, (byte) 0);
+            break;
+        case 6:
+            Narcissus.setStaticFloatField(field, 0.0f);
+            break;
+        case 7:
+            Narcissus.setStaticDoubleField(field, 0.0);
+            break;
+        default:
+            Narcissus.setStaticObjectField(field, null);
+            break;
+        }
+    }
+
+    /**
+     * Invoke an instance method using the typed invoker of the given kind.
+     *
+     * @param kind
+     *            the invoker to use
+     * @param obj
+     *            the object to invoke the method on
+     * @param method
+     *            the method to invoke
+     */
+    private static void invoke(final int kind, final Object obj, final Method method) {
+        switch (kind) {
+        case 0:
+            Narcissus.invokeVoidMethod(obj, method);
+            break;
+        case 1:
+            Narcissus.invokeIntMethod(obj, method);
+            break;
+        case 2:
+            Narcissus.invokeLongMethod(obj, method);
+            break;
+        case 3:
+            Narcissus.invokeShortMethod(obj, method);
+            break;
+        case 4:
+            Narcissus.invokeCharMethod(obj, method);
+            break;
+        case 5:
+            Narcissus.invokeBooleanMethod(obj, method);
+            break;
+        case 6:
+            Narcissus.invokeByteMethod(obj, method);
+            break;
+        case 7:
+            Narcissus.invokeFloatMethod(obj, method);
+            break;
+        case 8:
+            Narcissus.invokeDoubleMethod(obj, method);
+            break;
+        default:
+            Narcissus.invokeObjectMethod(obj, method);
+            break;
+        }
+    }
+
+    /**
+     * Invoke a static method using the typed invoker of the given kind.
+     *
+     * @param kind
+     *            the invoker to use
+     * @param method
+     *            the method to invoke
+     */
+    private static void invokeStatic(final int kind, final Method method) {
+        switch (kind) {
+        case 0:
+            Narcissus.invokeStaticVoidMethod(method);
+            break;
+        case 1:
+            Narcissus.invokeStaticIntMethod(method);
+            break;
+        case 2:
+            Narcissus.invokeStaticLongMethod(method);
+            break;
+        case 3:
+            Narcissus.invokeStaticShortMethod(method);
+            break;
+        case 4:
+            Narcissus.invokeStaticCharMethod(method);
+            break;
+        case 5:
+            Narcissus.invokeStaticBooleanMethod(method);
+            break;
+        case 6:
+            Narcissus.invokeStaticByteMethod(method);
+            break;
+        case 7:
+            Narcissus.invokeStaticFloatMethod(method);
+            break;
+        case 8:
+            Narcissus.invokeStaticDoubleMethod(method);
+            break;
+        default:
+            Narcissus.invokeStaticObjectMethod(method);
+            break;
+        }
+    }
+
+    @Test
+    public void testTypedFieldAccessorsRejectNullObject() throws Exception {
+        for (int kind = 0; kind < NUM_FIELD_KINDS; kind++) {
+            final Field field = Narcissus.findField(Target.class, FIELD_NAMES[kind]);
+            try {
+                getField(kind, null, field);
+                fail("field getter " + kind + " should have rejected a null object");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+            try {
+                setField(kind, null, field);
+                fail("field setter " + kind + " should have rejected a null object");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+        }
+    }
+
+    @Test
+    public void testTypedFieldAccessorsRejectNullField() {
+        final Target obj = new Target();
+        for (int kind = 0; kind < NUM_FIELD_KINDS; kind++) {
+            try {
+                getField(kind, obj, null);
+                fail("field getter " + kind + " should have rejected a null field");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+            try {
+                setField(kind, obj, null);
+                fail("field setter " + kind + " should have rejected a null field");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+        }
+    }
+
+    @Test
+    public void testTypedStaticFieldAccessorsRejectNullField() {
+        for (int kind = 0; kind < NUM_FIELD_KINDS; kind++) {
+            try {
+                getStaticField(kind, null);
+                fail("static field getter " + kind + " should have rejected a null field");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+            try {
+                setStaticField(kind, null);
+                fail("static field setter " + kind + " should have rejected a null field");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+        }
+    }
+
+    @Test
+    public void testTypedInvokersRejectNullObject() throws Exception {
+        for (int kind = 0; kind < NUM_METHOD_KINDS; kind++) {
+            final Method method = Narcissus.findMethod(Target.class, METHOD_NAMES[kind]);
+            try {
+                invoke(kind, null, method);
+                fail("invoker " + kind + " should have rejected a null object");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+        }
+    }
+
+    @Test
+    public void testTypedInvokersRejectNullMethod() {
+        final Target obj = new Target();
+        for (int kind = 0; kind < NUM_METHOD_KINDS; kind++) {
+            try {
+                invoke(kind, obj, null);
+                fail("invoker " + kind + " should have rejected a null method");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+            try {
+                invokeStatic(kind, null);
+                fail("static invoker " + kind + " should have rejected a null method");
+            } catch (final NullPointerException e) {
+                assertThat(e.getMessage()).contains("null");
+            }
+        }
+    }
+
+    @Test
+    public void testBoxingDispatchersRejectNullArguments() throws Exception {
+        final Target obj = new Target();
+        final Field field = Narcissus.findField(Target.class, "intField");
+        final Field staticField = Narcissus.findField(Target.class, "staticIntField");
+        final Method method = Narcissus.findMethod(Target.class, "retInt");
+        final Method staticMethod = Narcissus.findMethod(Narcissus.class, "findClass", String.class);
+
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.getField(null, field);
+            }
+        });
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.getField(obj, null);
+            }
+        });
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.setField(null, field, Integer.valueOf(0));
+            }
+        });
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.setField(obj, null, Integer.valueOf(0));
+            }
+        });
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.getStaticField(null);
+            }
+        });
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.setStaticField(null, Integer.valueOf(0));
+            }
+        });
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.invokeMethod(null, method);
+            }
+        });
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.invokeMethod(obj, null);
+            }
+        });
+        assertNullPointerException(new Runnable() {
+            @Override
+            public void run() {
+                Narcissus.invokeStaticMethod(null);
+            }
+        });
+
+        // These are the same objects, used above, that make the calls succeed when they are not null
+        assertThat(Narcissus.getField(obj, field)).isEqualTo(Integer.valueOf(0));
+        assertThat(Narcissus.getStaticField(staticField)).isEqualTo(Integer.valueOf(0));
+        assertThat(Narcissus.invokeMethod(obj, method)).isEqualTo(Integer.valueOf(0));
+        assertThat(Narcissus.invokeStaticMethod(staticMethod, "int")).isEqualTo(int.class);
+    }
+
+    @Test
+    public void testAllocateInstanceRejectsNull() {
+        try {
+            Narcissus.allocateInstance(null);
+            fail("allocateInstance(null) should have thrown NullPointerException");
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage()).contains("null");
+        }
+    }
+
+    @Test
+    public void testSneakyThrowRejectsNull() {
+        try {
+            Narcissus.sneakyThrow(null);
+            fail("sneakyThrow(null) should have thrown NullPointerException");
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage()).contains("null");
+        }
+    }
+
+    /**
+     * Assert that running the given task throws a {@link NullPointerException}.
+     *
+     * @param task
+     *            the task to run
+     */
+    private static void assertNullPointerException(final Runnable task) {
+        try {
+            task.run();
+            fail("Expected NullPointerException");
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage()).contains("null");
+        }
+    }
+}

--- a/src/test/java/io/github/toolfactory/narcissus/NarcissusVarargsTest.java
+++ b/src/test/java/io/github/toolfactory/narcissus/NarcissusVarargsTest.java
@@ -1,0 +1,252 @@
+package io.github.toolfactory.narcissus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests the handling of the arguments of a varargs method: trailing arguments passed individually are packed into
+ * an array of the declared varargs element type, and a single trailing argument that is already an array of the
+ * declared type is passed through unchanged.
+ */
+@ExtendWith(TestMethodNameLogger.class)
+public class NarcissusVarargsTest {
+
+    /** A class with varargs methods taking a reference element type, a primitive element type, and Object. */
+    public static class Varargs {
+        static String join(final String prefix, final String... parts) {
+            return prefix + Arrays.toString(parts);
+        }
+
+        static int sum(final int... vals) {
+            int total = 0;
+            for (int i = 0; i < vals.length; i++) {
+                total += vals[i];
+            }
+            return total;
+        }
+
+        static long sumLongs(final long... vals) {
+            long total = 0;
+            for (int i = 0; i < vals.length; i++) {
+                total += vals[i];
+            }
+            return total;
+        }
+
+        static double sumDoubles(final double... vals) {
+            double total = 0;
+            for (int i = 0; i < vals.length; i++) {
+                total += vals[i];
+            }
+            return total;
+        }
+
+        static String countBooleans(final boolean... vals) {
+            int numTrue = 0;
+            for (int i = 0; i < vals.length; i++) {
+                if (vals[i]) {
+                    numTrue++;
+                }
+            }
+            return numTrue + "/" + vals.length;
+        }
+
+        static String chars(final char... vals) {
+            return new String(vals);
+        }
+
+        static String bytes(final byte... vals) {
+            return Arrays.toString(vals);
+        }
+
+        static String shorts(final short... vals) {
+            return Arrays.toString(vals);
+        }
+
+        static String floats(final float... vals) {
+            return Arrays.toString(vals);
+        }
+
+        static String describe(final Object... vals) {
+            return Arrays.deepToString(vals);
+        }
+
+        String instanceJoin(final String... parts) {
+            return Arrays.toString(parts);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        if (!Narcissus.libraryLoaded) {
+            throw new RuntimeException("Narcissus library not loaded");
+        }
+    }
+
+    @Test
+    public void testTrailingArgsArePackedIntoAnArray() throws Exception {
+        final Method join = Narcissus.findMethod(Varargs.class, "join", String.class, String[].class);
+        assertThat(Narcissus.invokeStaticMethod(join, "p")).isEqualTo("p[]");
+        assertThat(Narcissus.invokeStaticMethod(join, "p", "a")).isEqualTo("p[a]");
+        assertThat(Narcissus.invokeStaticMethod(join, "p", "a", "b", "c")).isEqualTo("p[a, b, c]");
+    }
+
+    @Test
+    public void testPrePackedArrayIsPassedThrough() throws Exception {
+        final Method join = Narcissus.findMethod(Varargs.class, "join", String.class, String[].class);
+        // The array is passed through as-is, rather than being wrapped in another array
+        assertThat(Narcissus.invokeStaticMethod(join, "p", (Object) new String[] { "a", "b" })).isEqualTo("p[a, b]");
+        assertThat(Narcissus.invokeStaticMethod(join, "p", (Object) new String[0])).isEqualTo("p[]");
+    }
+
+    @Test
+    public void testPrePackedPrimitiveArrayIsPassedThrough() throws Exception {
+        final Method sum = Narcissus.findMethod(Varargs.class, "sum", int[].class);
+        assertThat(Narcissus.invokeStaticMethod(sum, (Object) new int[] { 1, 2, 3 })).isEqualTo(Integer.valueOf(6));
+        assertThat(Narcissus.invokeStaticMethod(sum, (Object) new int[0])).isEqualTo(Integer.valueOf(0));
+    }
+
+    @Test
+    public void testArrayOfWrongTypeIsNotPassedThrough() throws Exception {
+        final Method join = Narcissus.findMethod(Varargs.class, "join", String.class, String[].class);
+        // An Object[] is not a String[], so it is treated as a single trailing arg, and rejected because an
+        // Object[] cannot be stored in a String[]
+        try {
+            Narcissus.invokeStaticMethod(join, "p", (Object) new Object[] { "a" });
+            fail("join() should have rejected an Object[] as its varargs argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("incompatible type");
+        }
+        // A long[] is not an int[], and cannot be unboxed to an int either
+        final Method sum = Narcissus.findMethod(Varargs.class, "sum", int[].class);
+        try {
+            Narcissus.invokeStaticMethod(sum, (Object) new long[] { 1L });
+            fail("sum() should have rejected a long[] as its varargs argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong type");
+        }
+    }
+
+    @Test
+    public void testSubtypeArrayIsPassedThrough() throws Exception {
+        // A String[] is an Object[], so it is passed through rather than wrapped
+        final Method describe = Narcissus.findMethod(Varargs.class, "describe", Object[].class);
+        assertThat(Narcissus.invokeStaticMethod(describe, (Object) new String[] { "a", "b" })).isEqualTo("[a, b]");
+        // A single non-array arg is wrapped
+        assertThat(Narcissus.invokeStaticMethod(describe, "a")).isEqualTo("[a]");
+        // Args of mixed type are wrapped in an Object[]
+        assertThat(Narcissus.invokeStaticMethod(describe, "a", Integer.valueOf(1))).isEqualTo("[a, 1]");
+    }
+
+    @Test
+    public void testNullTrailingArgIsWrappedInAnArray() throws Exception {
+        // This matches the behavior of a varargs call site of the form join("p", (String) null)
+        final Method join = Narcissus.findMethod(Varargs.class, "join", String.class, String[].class);
+        assertThat(Narcissus.invokeStaticMethod(join, "p", (Object) null)).isEqualTo("p[null]");
+        assertThat(Narcissus.invokeStaticMethod(join, "p", null, "a")).isEqualTo("p[null, a]");
+    }
+
+    @Test
+    public void testNullTrailingArgIsRejectedForPrimitiveVarargs() throws Exception {
+        final Method sum = Narcissus.findMethod(Varargs.class, "sum", int[].class);
+        try {
+            Narcissus.invokeStaticMethod(sum, (Object) null);
+            fail("sum() should have rejected a null varargs argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("null argument");
+        }
+    }
+
+    @Test
+    public void testVarargsArgOfIncompatibleTypeIsRejected() throws Exception {
+        final Method join = Narcissus.findMethod(Varargs.class, "join", String.class, String[].class);
+        try {
+            Narcissus.invokeStaticMethod(join, "p", "a", Integer.valueOf(1));
+            fail("join() should have rejected an Integer varargs argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("incompatible type");
+        }
+    }
+
+    @Test
+    public void testTooFewArgsForNonVarargsParameters() throws Exception {
+        final Method join = Narcissus.findMethod(Varargs.class, "join", String.class, String[].class);
+        try {
+            Narcissus.invokeStaticMethod(join);
+            fail("join() should have rejected a call with no arguments");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong number of arguments");
+        }
+    }
+
+    @Test
+    public void testWideningConversionOfVarargsArgs() throws Exception {
+        final Method sum = Narcissus.findMethod(Varargs.class, "sum", int[].class);
+        assertThat(Narcissus.invokeStaticMethod(sum, Byte.valueOf((byte) 1), Short.valueOf((short) 2),
+                Character.valueOf((char) 3), Integer.valueOf(4))).isEqualTo(Integer.valueOf(10));
+
+        final Method sumLongs = Narcissus.findMethod(Varargs.class, "sumLongs", long[].class);
+        assertThat(Narcissus.invokeStaticMethod(sumLongs, Byte.valueOf((byte) 1), Integer.valueOf(2),
+                Long.valueOf(3L))).isEqualTo(Long.valueOf(6L));
+
+        final Method sumDoubles = Narcissus.findMethod(Varargs.class, "sumDoubles", double[].class);
+        assertThat(Narcissus.invokeStaticMethod(sumDoubles, Integer.valueOf(1), Float.valueOf(0.5f),
+                Double.valueOf(0.25))).isEqualTo(Double.valueOf(1.75));
+    }
+
+    @Test
+    public void testVarargsOfEveryPrimitiveElementType() throws Exception {
+        assertThat(Narcissus.invokeStaticMethod(Narcissus.findMethod(Varargs.class, "countBooleans",
+                boolean[].class), Boolean.TRUE, Boolean.FALSE, Boolean.TRUE)).isEqualTo("2/3");
+        assertThat(Narcissus.invokeStaticMethod(Narcissus.findMethod(Varargs.class, "chars", char[].class),
+                Character.valueOf('a'), Character.valueOf('b'))).isEqualTo("ab");
+        assertThat(Narcissus.invokeStaticMethod(Narcissus.findMethod(Varargs.class, "bytes", byte[].class),
+                Byte.valueOf((byte) 1), Byte.valueOf((byte) 2))).isEqualTo("[1, 2]");
+        assertThat(Narcissus.invokeStaticMethod(Narcissus.findMethod(Varargs.class, "shorts", short[].class),
+                Byte.valueOf((byte) 1), Short.valueOf((short) 2))).isEqualTo("[1, 2]");
+        assertThat(Narcissus.invokeStaticMethod(Narcissus.findMethod(Varargs.class, "floats", float[].class),
+                Integer.valueOf(1), Float.valueOf(2.5f))).isEqualTo("[1.0, 2.5]");
+    }
+
+    @Test
+    public void testVarargsArgOfWrongPrimitiveTypeIsRejected() throws Exception {
+        final Method sum = Narcissus.findMethod(Varargs.class, "sum", int[].class);
+        try {
+            Narcissus.invokeStaticMethod(sum, Integer.valueOf(1), Long.valueOf(2L));
+            fail("sum() should have rejected a long varargs argument");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wrong type");
+        }
+    }
+
+    @Test
+    public void testInstanceVarargsMethod() throws Exception {
+        final Varargs obj = new Varargs();
+        final Method join = Narcissus.findMethod(Varargs.class, "instanceJoin", String[].class);
+        assertThat(Narcissus.invokeMethod(obj, join, "a", "b")).isEqualTo("[a, b]");
+        assertThat(Narcissus.invokeMethod(obj, join, (Object) new String[] { "c" })).isEqualTo("[c]");
+        assertThat(Narcissus.invokeMethod(obj, join)).isEqualTo("[]");
+    }
+
+    @Test
+    public void testManyVarargsArgs() throws Exception {
+        // Each reference-typed arg needs a JNI local reference, and the default local reference capacity is 16
+        final Method describe = Narcissus.findMethod(Varargs.class, "describe", Object[].class);
+        final Object[] args = new Object[1000];
+        for (int i = 0; i < args.length; i++) {
+            args[i] = Integer.valueOf(i);
+        }
+        final String result = (String) Narcissus.invokeStaticMethod(describe, args);
+        assertThat(result).startsWith("[0, 1, 2,").endsWith(", 999]");
+
+        final Method sum = Narcissus.findMethod(Varargs.class, "sum", int[].class);
+        assertThat(Narcissus.invokeStaticMethod(sum, args)).isEqualTo(Integer.valueOf(999 * 1000 / 2));
+    }
+}


### PR DESCRIPTION
This came out of an audit of the native code done while tracking down JVM crashes reachable through ClassGraph's Narcissus reflection driver. It fixes 21 findings and adds a test suite that exercises every entry point on both its error and non-error paths.

## Crashes

**No field-type check in any of the 40 typed field accessors.** `getIntField`, `setLongField` and their 38 siblings checked that the field was non-null, non-static and declared by the receiver's class, but never that the field's *type* matched the accessor. The JNI `Get<Type>Field` family reads a fixed number of bytes at the field's offset with no type check of its own, so:

```java
Field intField = Narcissus.findField(MyClass.class, "intField");
Narcissus.getLongField(obj, intField);        // reads 4 bytes past the end of the field
Narcissus.setObjectField(obj, intField, "x"); // writes a pointer over a 4-byte int
```

Both reproduce as a SIGSEGV. Every typed accessor now checks the field type first, and `set<Type>Field` checks that the value is assignable to the field.

**`checkFieldValType` skipped its check entirely when the value was null**, so `setObjectField(obj, primitiveField, null)` wrote a null pointer over a primitive field and returned normally — silent memory corruption with no diagnostic. The field-type check now rejects the call before this point.

**The `jvalue` array was a variable-length array on the native stack, sized from the caller's argument-array length and allocated before the arity check.** Invoking a method with a large enough `Object[]` overflowed the native stack — SIGSEGV, no `hs_err` file. It is now a fixed-size array capped at `MAX_METHOD_PARAMS` (255, the JVM's argument-slot limit, JVMS 4.3.3), a method declaring more than that is rejected, and the arity check runs before anything is allocated.

**The varargs unboxing macro leaked the pinned or copied primitive array on all four of its error returns** (~800 MB leaked per 2000 failing calls in testing), and did not check for a pending exception after unboxing each element, which `-Xcheck:jni` flags per element. Every path now releases the array, with `JNI_ABORT` on the failing paths.

## Semantics

These bring Narcissus closer to `java.lang.reflect`, so a caller can swap drivers without changing behaviour.

- **Widening primitive conversion.** Argument and field-value unboxing demanded the exact boxed type via `IsSameObject`, so passing an `Integer` to a `long` parameter failed where `Method.invoke` succeeds. JLS 5.1.2 widening is now applied on both paths, in the native code and in the Java-side unboxing helpers. The helpers enumerate the boxed types explicitly, so a `BigInteger`, `BigDecimal` or `AtomicInteger` is still rejected rather than silently accepted via `Number`.
- **Varargs packing was inverted.** `Method.invoke` requires a pre-packed array for a varargs parameter; Narcissus always packed loose arguments and had no way to pass an array through. A non-null trailing argument that is assignable to the declared array type is now passed through, and loose arguments are still packed, so both call styles work.
- **`invokeMethod(obj, method, (Object[]) null)`** on a no-arg method now returns normally, as `Method.invoke` does, instead of throwing.
- **`setField`** threw `NullPointerException` or `ClassCastException` where reflection throws `IllegalArgumentException`; it now throws `IllegalArgumentException` naming the value's type, the field name and the field type.
- **`findClass("int[]")`** built the invalid name `[Lint;`. Primitive element types now map to their JVM descriptor letters, so `int[][]` becomes `[[I`, and `findClass("int")` returns `int.class` (JNI `FindClass` cannot look up a primitive, which has no binary name).
- **`ReflectionCache` resolved a shadowed field name to the superclass field**, disagreeing with `Narcissus.findField()`, which returns the most-derived declaration. `enumerateFields()` lists subclass fields first, so the cache now keeps the first declaration seen.
- **`getField`** threw `IllegalArgumentException` for a null object or field where the other five safe dispatchers throw `NullPointerException`; it now throws `NullPointerException` too. `findClass(null)` deliberately keeps its documented `IllegalArgumentException`, since that is a `String` argument with its own contract.

`findClass` resolves in the classloader that loaded Narcissus rather than the caller's — that is inherent to JNI `FindClass` and is not changed here, but it is now documented on the method, along with the fact that it throws `NoClassDefFoundError` rather than `ClassNotFoundException`.

## Latent JNI-spec violations

None of these are reachable today; they are the kind of thing that becomes a crash after an unrelated change.

- `JNI_OnUnload` discarded `GetEnv`'s return value and then dereferenced `env`, which is NULL if the unloading thread is not attached. It now returns early, and nulls each global ref as it releases it.
- `checkFieldStaticModifier` and `checkMethodStaticModifier` called `FindClass`/`ThrowNew` with an exception already pending — undefined per the JNI spec, fatal under `-Xcheck:jni` — and replaced the original exception with a generic message. They now return false and let the pending exception propagate.
- `JNI_OnLoad` passed the result of `GetStaticFieldID` straight into `GetStaticObjectField` at nine sites with no NULL check. These are now checked, so a JVM that is not what Narcissus expects fails cleanly at load time.
- `unbox` created three local references per argument and deleted none, with no bound on the local-reference table; the JNI spec only guarantees 16 slots. It now calls `EnsureLocalCapacity` up front and deletes each local ref as it finishes with it. `thrown()` used `ExceptionOccurred`, which itself allocates a local reference on every call; it now uses `ExceptionCheck`.
- `printClassName`, an unused debug helper, null-checked neither its argument nor the result of `GetStringUTFChars` before printing. Removed.

## `LibraryLoader`

- `System.load` throws `UnsatisfiedLinkError`, an `Error`, which escaped `catch (Exception)`: the temp-file cleanup below the `try` was skipped and the error was not wrapped with the "Could not load library" context. It now catches `Throwable`, and the extracted temp file is deleted whenever the load fails, on any filesystem, since a failed load leaves nothing mapped.
- On Windows a successfully loaded DLL cannot be deleted while it is mapped, so `%TEMP%` accumulated one `libnarcissus-win-x64_*.dll` per JVM run. Files left by earlier JVMs are now swept before the new one is extracted; a file still mapped into a running JVM simply fails to delete.
- 32-bit ARM (`os.arch` = `arm`) fell through to `archType = "x86"` and tried to load the x86 library. ARM is now checked before the word size, and 32-bit ARM is named `arm32`, which produces a clear "no library for this architecture" failure instead of a confusing one.
- `osName.contains("bsd")` was tested after `contains("nix")`, making the `OperatingSystem.BSD` constant unreachable and the `case BSD:` in `Narcissus`'s static initializer dead code.

## Tests

115 new tests in 13 files; **30 of them fail against the current `main`**. Total 555, green on JDK 8, 17 and 26.

| File | Covers |
|---|---|
| `NarcissusFieldTypeMismatchTest` | 9×9 accessor/field-type matrix, instance and static, get and set |
| `NarcissusFieldModifierMismatchTest` | static vs instance accessors both ways, receiver checks, boxing every field type |
| `NarcissusFieldValueConversionTest` | widening on field set for every source/target pair, null and non-boxed values rejected |
| `NarcissusFieldShadowingTest` | `findField` and `ReflectionCache` agree on a shadowed field |
| `NarcissusMethodReturnTypeTest` | 10×10 invoker/return-type matrix, instance and static |
| `NarcissusMethodArgumentTest` | widening matrix, null and non-boxed arguments, arity, `(Object[]) null` |
| `NarcissusVarargsTest` | packing and pass-through, all 8 primitive element types, null trailing argument, 1000-element call |
| `NarcissusManyParametersTest` | the 255-parameter boundary, and rejection beyond it |
| `NarcissusFindClassTest` | primitives, `void`, primitive and reference arrays, nested classes, internal-form names |
| `NarcissusFindMemberTest` | the three internal find natives directly, including their `NoSuchMethodError`/`NoSuchFieldError` paths |
| `NarcissusExceptionAndAccessTest` | exceptions propagate unwrapped; private and final member access |
| `NarcissusNullArgumentTest` | a null in every argument position of every entry point |
| `LibraryLoaderTest` | OS and architecture detection, extraction failure paths, stale-file sweeping |

## CI status: the `build` matrix is green, the `test-with-Java-7-and-later` matrix is red by construction

The four `build` jobs compile `narcissus.c` from source and run the suite. All four pass:

| Platform | Result |
|---|---|
| `ubuntu-latest` x64 | `Tests run: 555, Failures: 0, Errors: 0, Skipped: 0` |
| `windows-latest` x64 | `Tests run: 555, Failures: 0, Errors: 0, Skipped: 0` |
| `macos-latest` x64 | `Tests run: 555, Failures: 0, Errors: 0, Skipped: 0` |
| `macos-latest` arm64 | `Tests run: 555, Failures: 0, Errors: 0, Skipped: 0` |

All 52 `test-with-Java-7-and-later` jobs fail, on every platform and every JDK, with the same 30 failures. Those are exactly the 30 new tests that are meant to fail against the old native code: that matrix passes `-Dmassive_test_mode=enabled`, and the `massive-test` profile sets the `compile-native-lib` execution to phase `none`, so it tests the **committed** `lib/` binaries rather than compiling the source in the branch.

That is the right thing for its purpose -- it checks that the shipped binary works on JDK 8 through 24 without needing a C toolchain on 52 runners -- but it means any change to `narcissus.c` looks broken there until the binaries are rebuilt. The binaries are only rebuilt by the `build` job's "Push compiled library back to GitHub" step, which is gated on `github.event_name == 'push'`, so it never runs for a pull request. Every previous change to `narcissus.c` in this repo landed on `main` directly, in a commit whose message ends `Update libraries`, which is why this has not come up before.

So the red matrix is measuring stale binaries, not this change. The `build` matrix above is the one that actually exercises this code, and it is green on all four platforms.

## Note on `lib/`

I have left the prebuilt libraries at their current revision rather than committing a locally built one, since only `linux-x64` can be built here and a partial update would leave the four platforms inconsistent -- and CI overwrites them on merge in any case.

To regenerate them, the commit merged to `main` needs a message ending in `Update libraries`. The `build` job then commits a rebuilt library for each platform, and the `test-with-Java-7-and-later` matrix, which starts with a `git pull`, picks them up. Happy to commit a `linux-x64` binary here instead if you would rather see part of that matrix green before merging.
