### PR TITLE
Fall back to source level 8 on JDKs that no longer accept 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,11 @@ jobs:
       matrix:
         architecture: [x64, arm64]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # We build for JDK 7, but only test for JDK 8+, because Maven
-        # no longer supports JDK 7
-        java: [8, 11, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+        # The jar is built for JDK 7, but is only tested on JDK 8 and later,
+        # because Maven no longer runs on JDK 7. From JDK 20 onwards javac no
+        # longer accepts -source/-target 7, so the build falls back to 8 there
+        # -- see the jdk-20-and-later profile in pom.xml.
+        java: [8, 11, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
         exclude:
           - os: ubuntu-latest
             architecture: arm64
@@ -99,7 +101,7 @@ jobs:
           git pull origin ${{github.ref}}
       - if: endsWith(matrix.java, '-ea') != true
         name: Build and test with final version JDK
-        run: ./mvnw -B --no-transfer-progress clean test -X -e -Dproject_jdk_version=${{ matrix.java }} -DskipTests=false -Dmassive_test_mode=enabled
+        run: ./mvnw -B --no-transfer-progress clean test -X -e -DskipTests=false -Dmassive_test_mode=enabled
       - if: endsWith(matrix.java, '18-ea') == true
         name: Build and test with early access version JDK
         run: ./mvnw -B clean test -X -e -Dproject_jdk_version=18 -DskipTests=false -Dmassive_test_mode=enabled

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,23 @@
 
     <profiles>
         <profile>
+            <!-- javac dropped -source/-target 7 in JDK 20, under the JEP 182 retirement policy,
+            and will not accept anything lower than 8 from there on. The released jar is always
+            compiled for JDK 7: the release job runs on a JDK that still accepts 7, and passes
+            -Dproject_jdk_version=7 explicitly, so that if that ever stops being true the release
+            fails rather than silently shipping newer bytecode. The CI test matrix, on the other
+            hand, runs on every JDK up to the current release, so there it falls back to the
+            lowest version javac will still accept. When javac drops 8 as well, add another
+            profile here for that JDK range. -->
+            <id>jdk-20-and-later</id>
+            <activation>
+                <jdk>[20,)</jdk>
+            </activation>
+            <properties>
+                <project_jdk_version>8</project_jdk_version>
+            </properties>
+        </profile>
+        <profile>
             <id>mac</id>
             <activation>
                 <os>


### PR DESCRIPTION
`javac` dropped `-source`/`-target` 7 in JDK 20, under the [JEP 182](https://openjdk.org/jeps/182) retirement policy. Since `project_jdk_version` defaults to 7, any build on JDK 20 or later failed outright:

```
[ERROR] Source option 7 is no longer supported. Use 8 or later.
[ERROR] Target option 7 is no longer supported. Use 8 or later.
```

The CI test matrix avoided this by passing `-Dproject_jdk_version=${{ matrix.java }}`, which compiled the sources at the matrix JDK's own level — so a JDK 24 job compiled and tested Java 24 bytecode, not the Java 7 bytecode that ships. A plain `./mvnw test` on a current JDK still failed.

## Changes

**`pom.xml`** — a `jdk-20-and-later` profile, activated by `<jdk>[20,)</jdk>`, clamps `project_jdk_version` to 8, the lowest level `javac` still accepts there.

**`.github/workflows/ci.yml`** — the test matrix no longer overrides `project_jdk_version`, so it builds at the shipped target level on every JDK: 7 on JDK 8–19, 8 on JDK 20+. JDK 25 and 26 are added, so the matrix now covers JDK 8 through 26 on all three platforms (60 jobs, up from 52).

The released jar is unchanged and still compiled for JDK 7. The `release` job runs on a JDK that accepts 7 and passes `-Dproject_jdk_version=7` explicitly — that stays, so if the release JDK is ever bumped past 19 the release fails loudly instead of silently shipping newer bytecode.

## Verification

Locally, with the committed native libraries (`-Dmassive_test_mode=enabled`):

| JDK | effective `project_jdk_version` | `Narcissus.class` major version | tests |
|---|---|---|---|
| 8 | 7 (default) | 51 (Java 7) | 555 / 0 / 0 / 0 |
| 17 | 7 (default) | 51 (Java 7) | 555 / 0 / 0 / 0 |
| 26 | 8 (profile) | 52 (Java 8) | 555 / 0 / 0 / 0 |

The release path — `clean package -Dproject_jdk_version=7` on JDK 17 — still produces a jar in which every class is major 51, with `META-INF/versions/9/module-info.class` at major 53 and all four native libraries bundled.

## Note

The `-ea` branch of the test step is dead: the `java` matrix has no `-ea` entries, so `endsWith(matrix.java, '18-ea')` can never be true, and it hardcodes `-Dproject_jdk_version=18`. Left as-is, since it is unrelated to this change.
